### PR TITLE
[#9] add support for switching between different Story Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ cd /usr/pkgsrc/www/hackernews-tui
 
 ### Search View
 
-![Example of a Story View - Search](https://raw.githubusercontent.com/aome510/hackernews-TUI/main/examples/assets/story_search_view.png)
+![Example of a Search View](https://raw.githubusercontent.com/aome510/hackernews-TUI/main/examples/assets/story_search_view.png)
 
 ### Comment View
 
@@ -122,6 +122,8 @@ In each `View`, press `<ctrl-h>` to see a list of supported keyboard shortcuts a
 - `b`: Focus the story at the bottom
 - `{story_id} g`: Focus the {story_id}-th story
 - `<enter>`: Go the comment view associated with the focused story
+- `n`: Go to the next page
+- `p`: Go the previous page
 - `O`: Open in browser the link associated with the focused story
 - `S`: Open in browser the focused story
 - `<ctrl-d>/<alt-d>`: Toggle sort by date
@@ -156,7 +158,7 @@ Key shortcuts:
 - `<esc>`: Enter `Navigation` mode from `Search` mode
 - `<ctrl-d>/<alt-d>`: Toggle sort by date
 
-`Navigation` mode also supports all `StoryView`'s key shortcuts.
+`Navigation` mode also supports all `StoryView`'s key shortcuts beside paging shortcuts (`n`, `p`).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,66 @@
 # hackernews-TUI
 
-`hackernews_tui` is a Terminal UI to browse Hacker News.
+`hackernews_tui` is a Terminal UI to browse Hacker News with vim-like key bindings.
 
 `hackernews_tui` is written in Rust with the help of [Cursive TUI library](https://github.com/gyscos/cursive/). It uses [HN Algolia search APIs](https://hn.algolia.com/api/) to get Hacker News data.
 
 The application mainly consists of the following views:
 
-- `Story View - Front Page` displaying a list of stories in front page of Hacker News.
+- `Story View` displaying a list of stories. There are different kinds of `Story View` depending on the `tag` it uses to filter stories:
+  - `Front Page`: stories on the front-page
+  - `All Stories`: all stories
+  - `Ask HN`: ask HN stories only
+  - `Show HN`: show HN stories only
+  - `Jobs`: jobs stories only
 - `Comment View` displaying a list of comments in a story.
 - `Story View - Search` displaying a search bar and a list of stories matching the search query.
+
+### Why hackernews-TUI?
+
+If you are either
+
+- a Hacker News reader
+- a computer nerd who likes doing things on terminal
+- a vim key-bindings fan boy
+- a person who prefers navigating using keyboard to using mouse
+
+This application is a right tool for you :muscle:
 
 ### Table of Contents
 
 - [Install](#install)
 - [Examples](#examples)
 - [Documentation](#documentation)
+  - [Story View](#storyview)
+  - [Comment View](#commentview)
+  - [Search View](#searchview)
 - [Configuration](#configuration)
 
 ## Install
 
 ### Using cargo
 
+#### Install the latest version from [crates.io](https://crates.io/crates/hackernews_tui)
+
 Run `cargo install hackernews_tui` to install the application as a binary.
+
+#### Build from the `master` branch
+
+Run
+
+```shell
+# git clone https://github.com/aome510/hackernews-TUI.git
+# cd hackernews-TUI
+# cargo build --release
+```
+
+to build the application then run
+
+```shell
+# ./target/release/hackernews_tui
+```
+
+to run the application
 
 ### Arch Linux
 
@@ -44,14 +83,17 @@ $ cd /usr/pkgsrc/www/hackernews-tui
 
 ## Examples
 
-Story View - Front Page:
+### Story View
+
 ![Example of a Story View - Front Page](https://raw.githubusercontent.com/aome510/hackernews-TUI/main/examples/assets/story_view.png)
 
-Comment View:
-![Example of a Comment View](https://raw.githubusercontent.com/aome510/hackernews-TUI/main/examples/assets/comment_view.png)
+### Search View
 
-Story View - Search
 ![Example of a Story View - Search](https://raw.githubusercontent.com/aome510/hackernews-TUI/main/examples/assets/story_search_view.png)
+
+### Comment View:
+
+![Example of a Comment View](https://raw.githubusercontent.com/aome510/hackernews-TUI/main/examples/assets/comment_view.png)
 
 ## Documentation
 
@@ -61,13 +103,14 @@ In each `View`, press `<ctrl-h>` to see a list of supported keyboard shortcuts a
 
 **Global key shortcuts:**
 
-- `<ctrl-h>\<alt-h>`: Open the help dialog
-- `<ctrl-s>\<alt-s>`: Go to the story search
-- `<ctrl-f>\<alt-f>`: Go to the front page
-- `<ctrl-q>\<alt-q>`: Quit the application
-
-In case the above shortcuts don't work, you can always use the corresponding buttons at the bottom of the `View`:
-![Footer buttons](https://raw.githubusercontent.com/aome510/hackernews-TUI/main/examples/assets/footer_buttons.png)
+- `<ctrl-h>/<alt-h>`: Open the help dialog
+- `<ctrl-q>/<alt-q>`: Quit the application
+- `<ctrl-f>/<alt-f>`: Go to the front page
+- `<ctrl-s>/<alt-s>`: Go to the search page
+- `<ctrl-z>/<alt-z>`: Go to the all stories page
+- `<ctrl-x>/<alt-x>`: Go to the ask HN page
+- `<ctrl-c>/<alt-c>`: Go to the show HN page
+- `<ctrl-v>/<alt-v>`: Go to the jobs page
 
 **Key shortcuts for each `View`:**
 
@@ -81,6 +124,7 @@ In case the above shortcuts don't work, you can always use the corresponding but
 - `<enter>`: Go the comment view associated with the focused story
 - `O`: Open in browser the link associated with the focused story
 - `S`: Open in browser the focused story
+- `<ctrl-d>/<alt-d>`: Toggle sort by date
 
 #### CommentView
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The application mainly consists of the following views:
   - `Show HN`: show HN stories only
   - `Jobs`: jobs stories only
 - `Comment View` displaying a list of comments in a story.
-- `Story View - Search` displaying a search bar and a list of stories matching the search query.
+- `Serrch View` displaying a search bar and a list of stories matching the search query.
 
 ### Why hackernews-TUI?
 
@@ -91,7 +91,7 @@ $ cd /usr/pkgsrc/www/hackernews-tui
 
 ![Example of a Story View - Search](https://raw.githubusercontent.com/aome510/hackernews-TUI/main/examples/assets/story_search_view.png)
 
-### Comment View:
+### Comment View
 
 ![Example of a Comment View](https://raw.githubusercontent.com/aome510/hackernews-TUI/main/examples/assets/comment_view.png)
 

--- a/examples/hn-tui.toml
+++ b/examples/hn-tui.toml
@@ -17,13 +17,24 @@ delay = 2
 allows = ["front_page"]
 
 [client]
-# "client_timeout" is the application Client timeout (in seconds) when making an API request
+# "client_timeout" is the application's client timeout (in seconds) when making an API request
 client_timeout = 16
 
 [client.story_limit]
 # "story_limit" stores the number of maximum stories displayed in a page in each View
+# fields of "story_limit"
+# - "search" -> "Search View"
+# - "front_page" -> "Story View - Front Page"
+# - "story" -> "Story View - All Stories"
+# - "ask_hn" -> "Story View - Ask HN"
+# - "show_hn" -> "Story View - Show HN"
+# - "job" -> "Story View - Jobs"
 search = 10
 front_page = 25
+story = 20
+ask_hn = 15
+show_hn = 15
+job = 15
 
 [theme]
 # cursive's palette color

--- a/examples/hn-tui.toml
+++ b/examples/hn-tui.toml
@@ -1,11 +1,20 @@
-# "story_pooling" is a feature that allows the application to fetch stories
-# in background and store them in cache memory.
-# Views currently support "story_pooling":
-# - StoryView - Front Page
-story_pooling = true
 # "page_scrolling" is a feature that enables page-like behavior when navigating.
 # The application will automatically adjust the View based on the scrolling direction.
 page_scrolling = true
+
+[client.story_pooling]
+# "story_pooling" is a feature that allows the application to fetch stories
+# in background and store them in cache memory.
+enable = true
+# delay (in seconds) between two story API requests
+delay = 2
+# possible values for allows:
+# - "front_page" -> "Story View - Front Page"
+# - "story" -> "Story View - All Stories"
+# - "ask_hn" -> "Story View - Ask HN"
+# - "show_hn" -> "Story View - Show HN"
+# - "job" -> "Story View - Jobs"
+allows = ["front_page"]
 
 [client]
 # "client_timeout" is the application Client timeout (in seconds) when making an API request

--- a/examples/hn-tui.toml
+++ b/examples/hn-tui.toml
@@ -30,7 +30,7 @@ client_timeout = 16
 # - "show_hn" -> "Story View - Show HN"
 # - "job" -> "Story View - Jobs"
 search = 10
-front_page = 25
+front_page = 20
 story = 20
 ask_hn = 15
 show_hn = 15

--- a/examples/hn-tui.toml
+++ b/examples/hn-tui.toml
@@ -2,7 +2,7 @@
 # The application will automatically adjust the View based on the scrolling direction.
 page_scrolling = true
 
-[client.story_pooling]
+[story_pooling]
 # "story_pooling" is a feature that allows the application to fetch stories
 # in background and store them in cache memory.
 enable = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,10 @@ pub struct StoryPooling {
 #[derive(Deserialize, Debug, Clone)]
 pub struct StoryLimit {
     pub front_page: usize,
+    pub story: usize,
+    pub ask_hn: usize,
+    pub show_hn: usize,
+    pub job: usize,
     pub search: usize,
 }
 
@@ -44,6 +48,19 @@ impl Color {
         match theme::Color::parse(s) {
             None => None,
             Some(color) => Some(Color { color }),
+        }
+    }
+}
+
+impl StoryLimit {
+    pub fn get_story_limit_by_tag(&self, tag: &str) -> usize {
+        match tag {
+            "front_page" => self.front_page,
+            "story" => self.story,
+            "job" => self.job,
+            "ask_hn" => self.ask_hn,
+            "show_hn" => self.show_hn,
+            _ => panic!("unknown tag: {}", tag),
         }
     }
 }
@@ -135,8 +152,12 @@ impl Default for Config {
             page_scrolling: true,
             client: Client {
                 story_limit: StoryLimit {
-                    front_page: 25,
                     search: 10,
+                    front_page: 25,
+                    story: 20,
+                    ask_hn: 15,
+                    show_hn: 15,
+                    job: 15,
                 },
                 client_timeout: 16,
             },

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,10 +9,17 @@ use cursive::theme;
 #[derive(Deserialize, Debug, Clone)]
 /// Config is a struct storing the application's configurations
 pub struct Config {
-    pub story_pooling: bool,
+    pub story_pooling: StoryPooling,
     pub page_scrolling: bool,
     pub client: Client,
     pub theme: Theme,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct StoryPooling {
+    pub enable: bool,
+    pub delay: u64,
+    pub allows: Vec<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -120,7 +127,11 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            story_pooling: true,
+            story_pooling: StoryPooling {
+                enable: true,
+                delay: 2,
+                allows: vec!["front_page".to_string()],
+            },
             page_scrolling: true,
             client: Client {
                 story_limit: StoryLimit {

--- a/src/config.rs
+++ b/src/config.rs
@@ -153,7 +153,7 @@ impl Default for Config {
             client: Client {
                 story_limit: StoryLimit {
                     search: 10,
-                    front_page: 25,
+                    front_page: 20,
                     story: 20,
                     ask_hn: 15,
                     show_hn: 15,

--- a/src/hn_client.rs
+++ b/src/hn_client.rs
@@ -357,7 +357,7 @@ impl HNClient {
     }
 
     /// Get a list of stories filtering on a specific tag
-    pub fn get_stories_by_tag(&self, tag: &str, by_date: bool) -> Result<Vec<Story>> {
+    pub fn get_stories_by_tag(&self, tag: &str, by_date: bool, page: usize) -> Result<Vec<Story>> {
         let story_limit = CONFIG
             .get()
             .unwrap()
@@ -365,11 +365,12 @@ impl HNClient {
             .story_limit
             .get_story_limit_by_tag(tag);
         let request_url = format!(
-            "{}/{}?tags={}&hitsPerPage={}",
+            "{}/{}?tags={}&hitsPerPage={}&page={}",
             HN_ALGOLIA_PREFIX,
             if by_date { "search_by_date" } else { "search" },
             tag,
-            story_limit
+            story_limit,
+            page
         );
         let time = SystemTime::now();
         let response = self
@@ -379,9 +380,10 @@ impl HNClient {
             .into_json::<StoriesResponse>()?;
         if let Ok(elapsed) = time.elapsed() {
             info!(
-                "get stories (tag={}, by_date={}) took {}ms",
+                "get stories (tag={}, by_date={}, page={}) took {}ms",
                 tag,
                 by_date,
+                page,
                 elapsed.as_millis()
             );
         }

--- a/src/hn_client.rs
+++ b/src/hn_client.rs
@@ -356,7 +356,7 @@ impl HNClient {
         Ok(response.parse_into_stories())
     }
 
-    /// Get a list of stories on HN front page
+    /// Get a list of stories filtering on a specific tag
     pub fn get_stories_by_tag(&self, tag: &str, by_date: bool) -> Result<Vec<Story>> {
         let front_page_story_limit = CONFIG.get().unwrap().client.story_limit.front_page;
         let request_url = format!(

--- a/src/hn_client.rs
+++ b/src/hn_client.rs
@@ -358,13 +358,18 @@ impl HNClient {
 
     /// Get a list of stories filtering on a specific tag
     pub fn get_stories_by_tag(&self, tag: &str, by_date: bool) -> Result<Vec<Story>> {
-        let front_page_story_limit = CONFIG.get().unwrap().client.story_limit.front_page;
+        let story_limit = CONFIG
+            .get()
+            .unwrap()
+            .client
+            .story_limit
+            .get_story_limit_by_tag(tag);
         let request_url = format!(
             "{}/{}?tags={}&hitsPerPage={}",
             HN_ALGOLIA_PREFIX,
             if by_date { "search_by_date" } else { "search" },
             tag,
-            front_page_story_limit
+            story_limit
         );
         let time = SystemTime::now();
         let response = self

--- a/src/hn_client.rs
+++ b/src/hn_client.rs
@@ -346,8 +346,9 @@ impl HNClient {
             .into_json::<StoriesResponse>()?;
         if let Ok(elapsed) = time.elapsed() {
             info!(
-                "get matched stories with query {} took {}ms",
+                "get matched stories with query {} (by_date={}) took {}ms",
                 query,
+                by_date,
                 elapsed.as_millis()
             );
         }
@@ -356,11 +357,14 @@ impl HNClient {
     }
 
     /// Get a list of stories on HN front page
-    pub fn get_front_page_stories(&self) -> Result<Vec<Story>> {
+    pub fn get_stories_by_tag(&self, tag: &str, by_date: bool) -> Result<Vec<Story>> {
         let front_page_story_limit = CONFIG.get().unwrap().client.story_limit.front_page;
         let request_url = format!(
-            "{}/search?tags=front_page&hitsPerPage={}",
-            HN_ALGOLIA_PREFIX, front_page_story_limit
+            "{}/{}?tags={}&hitsPerPage={}",
+            HN_ALGOLIA_PREFIX,
+            if by_date { "search_by_date" } else { "search" },
+            tag,
+            front_page_story_limit
         );
         let time = SystemTime::now();
         let response = self
@@ -369,7 +373,12 @@ impl HNClient {
             .call()?
             .into_json::<StoriesResponse>()?;
         if let Ok(elapsed) = time.elapsed() {
-            info!("get front-page stories took {}ms", elapsed.as_millis());
+            info!(
+                "get stories (tag={}, by_date={}) took {}ms",
+                tag,
+                by_date,
+                elapsed.as_millis()
+            );
         }
 
         Ok(response.parse_into_stories())

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn set_up_global_callbacks(s: &mut Cursive, client: &hn_client::HNClient) {
         {
             let client = client.clone();
             move |s| {
-                story_view::add_story_view_layer(s, &client);
+                story_view::add_story_view_layer(s, &client, "front_page", false);
             }
         },
     );
@@ -89,7 +89,7 @@ fn run() {
     });
 
     let client = hn_client::HNClient::new().unwrap();
-    story_view::add_story_view_layer(&mut s, &client);
+    story_view::add_story_view_layer(&mut s, &client, "front_page", false);
 
     set_up_global_callbacks(&mut s, &client);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,12 @@ use clap::*;
 use prelude::*;
 
 fn set_up_global_callbacks(s: &mut Cursive, client: &hn_client::HNClient) {
+    // we already have <alt-q>/<ctrl-q> for quit
     s.clear_global_callbacks(Event::CtrlChar('c'));
+
+    // .............................................................
+    // global shortcuts for switching between different Story Views
+    // .............................................................
 
     s.set_on_post_event(
         EventTrigger::from_fn(|e| match e {
@@ -74,6 +79,10 @@ fn set_up_global_callbacks(s: &mut Cursive, client: &hn_client::HNClient) {
             }
         },
     );
+
+    // .........................................
+    // end of switching shortcuts for StoryView
+    // .........................................
 
     s.set_on_post_event(
         EventTrigger::from_fn(|e| match e {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn set_up_global_callbacks(s: &mut Cursive, client: &hn_client::HNClient) {
         {
             let client = client.clone();
             move |s| {
-                story_view::add_story_view_layer(s, &client, "front_page", false);
+                story_view::add_story_view_layer(s, &client, "front_page", false, 0);
             }
         },
     );
@@ -36,7 +36,7 @@ fn set_up_global_callbacks(s: &mut Cursive, client: &hn_client::HNClient) {
         {
             let client = client.clone();
             move |s| {
-                story_view::add_story_view_layer(s, &client, "story", true);
+                story_view::add_story_view_layer(s, &client, "story", true, 0);
             }
         },
     );
@@ -49,7 +49,7 @@ fn set_up_global_callbacks(s: &mut Cursive, client: &hn_client::HNClient) {
         {
             let client = client.clone();
             move |s| {
-                story_view::add_story_view_layer(s, &client, "ask_hn", true);
+                story_view::add_story_view_layer(s, &client, "ask_hn", true, 0);
             }
         },
     );
@@ -62,7 +62,7 @@ fn set_up_global_callbacks(s: &mut Cursive, client: &hn_client::HNClient) {
         {
             let client = client.clone();
             move |s| {
-                story_view::add_story_view_layer(s, &client, "show_hn", true);
+                story_view::add_story_view_layer(s, &client, "show_hn", true, 0);
             }
         },
     );
@@ -75,7 +75,7 @@ fn set_up_global_callbacks(s: &mut Cursive, client: &hn_client::HNClient) {
         {
             let client = client.clone();
             move |s| {
-                story_view::add_story_view_layer(s, &client, "job", true);
+                story_view::add_story_view_layer(s, &client, "job", true, 0);
             }
         },
     );
@@ -152,7 +152,7 @@ fn run() {
     });
 
     let client = hn_client::HNClient::new().unwrap();
-    story_view::add_story_view_layer(&mut s, &client, "front_page", false);
+    story_view::add_story_view_layer(&mut s, &client, "front_page", false, 0);
 
     set_up_global_callbacks(&mut s, &client);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ use clap::*;
 use prelude::*;
 
 fn set_up_global_callbacks(s: &mut Cursive, client: &hn_client::HNClient) {
+    s.clear_global_callbacks(Event::CtrlChar('c'));
+
     s.set_on_post_event(
         EventTrigger::from_fn(|e| match e {
             Event::CtrlChar('f') | Event::AltChar('f') => true,
@@ -17,6 +19,58 @@ fn set_up_global_callbacks(s: &mut Cursive, client: &hn_client::HNClient) {
             let client = client.clone();
             move |s| {
                 story_view::add_story_view_layer(s, &client, "front_page", false);
+            }
+        },
+    );
+
+    s.set_on_post_event(
+        EventTrigger::from_fn(|e| match e {
+            Event::CtrlChar('z') | Event::AltChar('z') => true,
+            _ => false,
+        }),
+        {
+            let client = client.clone();
+            move |s| {
+                story_view::add_story_view_layer(s, &client, "story", true);
+            }
+        },
+    );
+
+    s.set_on_post_event(
+        EventTrigger::from_fn(|e| match e {
+            Event::CtrlChar('x') | Event::AltChar('x') => true,
+            _ => false,
+        }),
+        {
+            let client = client.clone();
+            move |s| {
+                story_view::add_story_view_layer(s, &client, "ask_hn", true);
+            }
+        },
+    );
+
+    s.set_on_post_event(
+        EventTrigger::from_fn(|e| match e {
+            Event::CtrlChar('c') | Event::AltChar('c') => true,
+            _ => false,
+        }),
+        {
+            let client = client.clone();
+            move |s| {
+                story_view::add_story_view_layer(s, &client, "show_hn", true);
+            }
+        },
+    );
+
+    s.set_on_post_event(
+        EventTrigger::from_fn(|e| match e {
+            Event::CtrlChar('v') | Event::AltChar('v') => true,
+            _ => false,
+        }),
+        {
+            let client = client.clone();
+            move |s| {
+                story_view::add_story_view_layer(s, &client, "job", true);
             }
         },
     );

--- a/src/view/async_view.rs
+++ b/src/view/async_view.rs
@@ -1,4 +1,5 @@
 use super::error_view::{self, ErrorViewEnum, ErrorViewWrapper};
+use super::utils::get_story_view_desc_by_tag;
 
 use crate::prelude::*;
 use cursive_async_view::AsyncView;
@@ -48,21 +49,25 @@ pub fn get_comment_view_async(
     )
 }
 
-/// Return an async view wraps StoryView (front page)
-/// with a loading screen when loading data
-pub fn get_front_page_story_view_async(
+/// Return an async view wraps StoryView with a loading screen when loading data
+pub fn get_story_view_async(
     siv: &mut Cursive,
     client: &hn_client::HNClient,
+    tag: &'static str,
+    by_date: bool,
 ) -> impl View {
     AsyncView::new_with_bg_creator(
         siv,
         {
             let client = client.clone();
-            move || match client.get_front_page_stories() {
+            move || match client.get_stories_by_tag(tag, by_date) {
                 Ok(stories) => Ok(Ok(stories)),
                 Err(err) => {
-                    warn!("failed to get front page stories: {:#?}\nRetrying...", err);
-                    Ok(client.get_front_page_stories())
+                    warn!(
+                        "failed to get stories (tag={}, by_date={}): {:#?}\nRetrying...",
+                        err, tag, by_date
+                    );
+                    Ok(client.get_stories_by_tag(tag, by_date))
                 }
             }
         },
@@ -71,12 +76,12 @@ pub fn get_front_page_story_view_async(
             move |result| {
                 ErrorViewWrapper::new(match result {
                     Ok(stories) => ErrorViewEnum::Ok(story_view::get_story_view(
-                        "Story View - Front Page",
+                        &get_story_view_desc_by_tag(tag),
                         stories,
                         &client,
                     )),
                     Err(err) => ErrorViewEnum::Err(error_view::get_error_view(
-                        "failed to get front page stories",
+                        &format!("failed to get stories (tag={}, by_date={})", tag, by_date),
                         err,
                         &client,
                     )),

--- a/src/view/async_view.rs
+++ b/src/view/async_view.rs
@@ -41,7 +41,6 @@ pub fn get_comment_view_async(
                     Err(err) => ErrorViewEnum::Err(error_view::get_error_view(
                         &format!("failed to get comments from story (id={})", id),
                         err,
-                        &client,
                     )),
                 })
             }
@@ -90,7 +89,6 @@ pub fn get_story_view_async(
                             tag, by_date, page
                         ),
                         err,
-                        &client,
                     )),
                 })
             }

--- a/src/view/async_view.rs
+++ b/src/view/async_view.rs
@@ -76,9 +76,11 @@ pub fn get_story_view_async(
             move |result| {
                 ErrorViewWrapper::new(match result {
                     Ok(stories) => ErrorViewEnum::Ok(story_view::get_story_view(
-                        &get_story_view_desc_by_tag(tag),
+                        &get_story_view_desc_by_tag(tag, by_date),
                         stories,
                         &client,
+                        tag,
+                        by_date,
                     )),
                     Err(err) => ErrorViewEnum::Err(error_view::get_error_view(
                         &format!("failed to get stories (tag={}, by_date={})", tag, by_date),

--- a/src/view/comment_view.rs
+++ b/src/view/comment_view.rs
@@ -301,7 +301,7 @@ pub fn get_comment_view(
     let mut view = LinearLayout::vertical()
         .child(status_bar)
         .child(main_view)
-        .child(construct_footer_view::<CommentView>(client));
+        .child(construct_footer_view::<CommentView>());
     view.set_focus_index(1).unwrap_or_else(|_| {});
 
     let id = story.id;

--- a/src/view/error_view.rs
+++ b/src/view/error_view.rs
@@ -4,7 +4,7 @@ use super::utils::*;
 use crate::{impl_view_for_fn_wrapper, prelude::*};
 
 /// Return an ErrorView given an error
-pub fn get_error_view(err_desc: &str, err: Error, client: &hn_client::HNClient) -> impl View {
+pub fn get_error_view(err_desc: &str, err: Error) -> impl View {
     let main_view = Dialog::around(
         LinearLayout::vertical()
             .child(TextView::new(err_desc))
@@ -16,7 +16,7 @@ pub fn get_error_view(err_desc: &str, err: Error, client: &hn_client::HNClient) 
     LinearLayout::vertical()
         .child(get_status_bar_with_desc("Error View"))
         .child(main_view)
-        .child(construct_footer_view::<DefaultHelpView>(client))
+        .child(construct_footer_view::<DefaultHelpView>())
 }
 
 /// An enum representing a normal View or an error View

--- a/src/view/help_view.rs
+++ b/src/view/help_view.rs
@@ -134,8 +134,10 @@ impl HasHelpView for StoryView {
                     ("`{story_id} g`", "Focus the {story_id}-th story"),
                     (
                         "<enter>",
-                        "Go the comment view associated with the focused story",
+                        "Go to the comment view associated with the focused story",
                     ),
+                    ("n", "Go to the next page"),
+                    ("p", "Go the previous page"),
                 ],
             ),
             (

--- a/src/view/help_view.rs
+++ b/src/view/help_view.rs
@@ -98,7 +98,11 @@ macro_rules! other_key_shortcuts {
                     ($k, $d),
                 )*
                 ("<ctrl-f>/<alt-f>", "Go to the front page"),
-                ("<ctrl-s>/<alt-s>", "Go to the story search page"),
+                ("<ctrl-s>/<alt-s>", "Go to the search page"),
+                ("<ctrl-z>/<alt-z>", "Go to the all stories page"),
+                ("<ctrl-x>/<alt-x>", "Go to the ask HN page"),
+                ("<ctrl-c>/<alt-c>", "Go to the show HN page"),
+                ("<ctrl-v>/<alt-v>", "Go to the jobs page"),
                 ("<ctrl-q>/<alt-q>", "Quit the application"),
                 ("<esc>", "Close this help dialog"),
             ],
@@ -144,7 +148,7 @@ impl HasHelpView for StoryView {
                     ("S", "Open in browser the focused story"),
                 ],
             ),
-            other_key_shortcuts!(),
+            other_key_shortcuts!(("<ctrl-d>/<alt-d>", "Toggle sort by date")),
         ])
     }
 }

--- a/src/view/help_view.rs
+++ b/src/view/help_view.rs
@@ -18,7 +18,10 @@ impl HelpView {
     fn construct_key_view(key: (String, String), max_key_width: usize) -> impl View {
         let key_string = StyledString::styled(
             key.0,
-            ColorStyle::back(get_config_theme().code_block_bg.color),
+            ColorStyle::new(
+                PaletteColor::TitlePrimary,
+                get_config_theme().code_block_bg.color,
+            ),
         );
         let desc_string = StyledString::plain(key.1);
         LinearLayout::horizontal()

--- a/src/view/search_view.rs
+++ b/src/view/search_view.rs
@@ -35,7 +35,7 @@ impl SearchView {
         client: &hn_client::HNClient,
     ) -> impl View {
         let client = client.clone();
-        story_view::get_story_main_view(stories, &client)
+        story_view::get_story_main_view(stories, &client).full_height()
     }
 
     fn get_query_text_view(query: String) -> impl View {

--- a/src/view/search_view.rs
+++ b/src/view/search_view.rs
@@ -35,7 +35,7 @@ impl SearchView {
         client: &hn_client::HNClient,
     ) -> impl View {
         let client = client.clone();
-        story_view::get_story_main_view(stories, &client).full_height()
+        story_view::get_story_main_view(stories, &client, 0).full_height()
     }
 
     fn get_query_text_view(query: String) -> impl View {

--- a/src/view/search_view.rs
+++ b/src/view/search_view.rs
@@ -232,7 +232,7 @@ pub fn get_search_view(client: &hn_client::HNClient, cb_sink: CbSink) -> impl Vi
     let mut view = LinearLayout::vertical()
         .child(get_status_bar_with_desc("Search View"))
         .child(main_view)
-        .child(construct_footer_view::<SearchView>(&client));
+        .child(construct_footer_view::<SearchView>());
     view.set_focus_index(1).unwrap_or_else(|_| {});
 
     OnEventView::new(view).on_event(

--- a/src/view/search_view.rs
+++ b/src/view/search_view.rs
@@ -40,7 +40,7 @@ impl SearchView {
 
     fn get_query_text_view(query: String) -> impl View {
         let mut style_string = StyledString::styled(
-            format!("Query:"),
+            format!("Search Query:"),
             ColorStyle::new(
                 PaletteColor::TitlePrimary,
                 get_config_theme().search_highlight_bg.color,
@@ -230,7 +230,7 @@ pub fn get_search_view(client: &hn_client::HNClient, cb_sink: CbSink) -> impl Vi
     let client = client.clone();
     let main_view = get_search_main_view(&client, cb_sink);
     let mut view = LinearLayout::vertical()
-        .child(get_status_bar_with_desc("Story View - Search"))
+        .child(get_status_bar_with_desc("Search View"))
         .child(main_view)
         .child(construct_footer_view::<SearchView>(&client));
     view.set_focus_index(1).unwrap_or_else(|_| {});

--- a/src/view/story_view.rs
+++ b/src/view/story_view.rs
@@ -212,7 +212,7 @@ pub fn get_story_view(
     let mut view = LinearLayout::vertical()
         .child(get_status_bar_with_desc(desc))
         .child(main_view)
-        .child(construct_footer_view::<StoryView>(client));
+        .child(construct_footer_view::<StoryView>());
     view.set_focus_index(1).unwrap_or_else(|_| {});
 
     let story_pooling = &CONFIG.get().unwrap().story_pooling;

--- a/src/view/story_view.rs
+++ b/src/view/story_view.rs
@@ -267,14 +267,14 @@ pub fn get_story_view(
             let client = client.clone();
             move |s| {
                 if page > 0 {
-                    add_story_view_layer(s, &client, tag, !by_date, page - 1);
+                    add_story_view_layer(s, &client, tag, by_date, page - 1);
                 }
             }
         })
         .on_event('n', {
             let client = client.clone();
             move |s| {
-                add_story_view_layer(s, &client, tag, !by_date, page + 1);
+                add_story_view_layer(s, &client, tag, by_date, page + 1);
             }
         })
 }

--- a/src/view/story_view.rs
+++ b/src/view/story_view.rs
@@ -231,8 +231,13 @@ pub fn get_story_view(
 }
 
 /// Add StoryView as a new layer to the main Cursive View
-pub fn add_story_view_layer(s: &mut Cursive, client: &hn_client::HNClient) {
-    let async_view = async_view::get_front_page_story_view_async(s, client);
+pub fn add_story_view_layer(
+    s: &mut Cursive,
+    client: &hn_client::HNClient,
+    tag: &'static str,
+    by_date: bool,
+) {
+    let async_view = async_view::get_story_view_async(s, client, tag, by_date);
     s.pop_layer();
     s.screen_mut().add_transparent_layer(Layer::new(async_view));
 }

--- a/src/view/utils.rs
+++ b/src/view/utils.rs
@@ -36,7 +36,7 @@ pub fn shorten_url(url: &str) -> String {
 }
 
 /// Construct a simple footer view
-pub fn construct_footer_view<T: HasHelpView>(client: &hn_client::HNClient) -> impl View {
+pub fn construct_footer_view<T: HasHelpView>() -> impl View {
     LinearLayout::horizontal()
         .child(
             TextView::new(StyledString::styled(
@@ -48,14 +48,6 @@ pub fn construct_footer_view<T: HasHelpView>(client: &hn_client::HNClient) -> im
         )
         .child(
             LinearLayout::horizontal()
-                .child(Button::new_raw("[front page] ", {
-                    let client = client.clone();
-                    move |s| story_view::add_story_view_layer(s, &client, "front_page", false, 0)
-                }))
-                .child(Button::new_raw("[search] ", {
-                    let client = client.clone();
-                    move |s| search_view::add_search_view_layer(s, &client)
-                }))
                 .child(Button::new_raw("[help] ", |s| {
                     s.add_layer(T::construct_help_view())
                 }))

--- a/src/view/utils.rs
+++ b/src/view/utils.rs
@@ -80,13 +80,15 @@ pub fn get_status_bar_with_desc(desc: &str) -> impl View {
 }
 
 /// Construct StoryView based on the filtering tag
-pub fn get_story_view_desc_by_tag(tag: &str) -> String {
+pub fn get_story_view_desc_by_tag(tag: &str, by_date: bool) -> String {
     "Story View - ".to_owned()
         + match tag {
             "front_page" => "Front Page",
-            "job" => "Jos",
-            "ask_hn" => "Ask",
-            "show_hn" => "Show",
+            "story" => "All Stories",
+            "job" => "Jobs",
+            "ask_hn" => "Ask HN",
+            "show_hn" => "Show HN",
             _ => panic!("unknown tag: {}", tag),
         }
+        + if by_date { " (new)" } else { " (popular)" }
 }

--- a/src/view/utils.rs
+++ b/src/view/utils.rs
@@ -50,7 +50,7 @@ pub fn construct_footer_view<T: HasHelpView>(client: &hn_client::HNClient) -> im
             LinearLayout::horizontal()
                 .child(Button::new_raw("[front page] ", {
                     let client = client.clone();
-                    move |s| story_view::add_story_view_layer(s, &client, "front_page", false)
+                    move |s| story_view::add_story_view_layer(s, &client, "front_page", false, 0)
                 }))
                 .child(Button::new_raw("[search] ", {
                     let client = client.clone();
@@ -80,15 +80,18 @@ pub fn get_status_bar_with_desc(desc: &str) -> impl View {
 }
 
 /// Construct StoryView based on the filtering tag
-pub fn get_story_view_desc_by_tag(tag: &str, by_date: bool) -> String {
-    "Story View - ".to_owned()
-        + match tag {
+pub fn get_story_view_desc_by_tag(tag: &str, by_date: bool, page: usize) -> String {
+    format!(
+        "Story View - {} ({}, page: {})",
+        match tag {
             "front_page" => "Front Page",
             "story" => "All Stories",
             "job" => "Jobs",
             "ask_hn" => "Ask HN",
             "show_hn" => "Show HN",
             _ => panic!("unknown tag: {}", tag),
-        }
-        + if by_date { " (new)" } else { " (popular)" }
+        },
+        if by_date { "new" } else { "popular" },
+        page + 1
+    )
 }

--- a/src/view/utils.rs
+++ b/src/view/utils.rs
@@ -50,7 +50,7 @@ pub fn construct_footer_view<T: HasHelpView>(client: &hn_client::HNClient) -> im
             LinearLayout::horizontal()
                 .child(Button::new_raw("[front page] ", {
                     let client = client.clone();
-                    move |s| story_view::add_story_view_layer(s, &client)
+                    move |s| story_view::add_story_view_layer(s, &client, "front_page", false)
                 }))
                 .child(Button::new_raw("[search] ", {
                     let client = client.clone();
@@ -77,4 +77,16 @@ pub fn get_status_bar_with_desc(desc: &str) -> impl View {
         .full_width(),
         ColorStyle::back(get_config_theme().status_bar_bg.color),
     )
+}
+
+/// Construct StoryView based on the filtering tag
+pub fn get_story_view_desc_by_tag(tag: &str) -> String {
+    "Story View - ".to_owned()
+        + match tag {
+            "front_page" => "Front Page",
+            "job" => "Jos",
+            "ask_hn" => "Ask",
+            "show_hn" => "Show",
+            _ => panic!("unknown tag: {}", tag),
+        }
 }


### PR DESCRIPTION
Resolve #9 
- add more project descriptions in `README`
- add support for `jobs`, `ask_hn`, `all`, `show_hn` Story Views:
  - modify `documentation`
  - modify `examples`
  - implement paging for above Views
  - implement switching between `search` and `search_by_date` for above Views
- add more config options for `story_pooling`
- add more config options for `story_limit`