### PR TITLE
Add `article_parse_command`

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ article_parse_command = {command = "mercury-parser", options = ["--format", "mar
 
 If you don't want to implement an article parser by your own, one way to configure `article_parse_command` is to use [`mercury-parser`](https://github.com/postlight/mercury-parser#installation), a web parser tool that `hackernews_tui` has been using by default since the version `0.6.0`. `mercury-parser` is powerful and stable. However, in some cases, the text content it returns when parsing HTML `code` tags has weird indentation.
 
-Another alternative is [`article-md-cli`](https://github.com/aome510/article-md-cli), a package I wrote for parsing article's content into a markdown format. Under the hood, it uses [mozilla's readability](https://github.com/mozilla/readability), so the parsed text content for the HTML `code` tags look nicer.
+Another alternative is to use [`article_md`](https://github.com/aome510/article-md-cli), a CLI package I wrote for parsing article's content into a markdown format. Under the hood, it uses [mozilla's readability](https://github.com/mozilla/readability), so the parsed text content for the HTML `code` tags look nicer.
 
 ### User-defined shortcuts
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ $ cd /usr/pkgsrc/www/hackernews-tui
 # make install
 ```
 
-
 ## Examples
 
 ### Demo
@@ -233,7 +232,7 @@ then modify the config options in `~/.config/hn-tui.toml` based on your preferen
 
 To enable viewing a web page in reader mode with `Article View`, you must configure the `article_parse_command` field in your configuration file:
 
-``` yaml
+```yaml
 # "article_parse_command" defines a command to parse a web article's content
 # to a markdown format. The parsed data is then used to render `ArticleView`
 # of the corresponding article.
@@ -253,9 +252,9 @@ article_parse_command = {command = "mercury-parser", options = ["--format", "mar
 # article_parse_command = {command = "article_md", options = []}
 ```
 
-If you don't want to implement an article parser by your own, one way to configure `article_parse_command` is to use [`mercury-parser`](https://github.com/postlight/mercury-parser#installation), a web parser tool that `hackernews_tui` has been using by default since the version `0.6.0`. `mercury-parser` is powerful and stable. However, in some cases, the text content it returns when parsing HTML `code` tags has weird indentation.
+If you don't want to implement an article parser by your own, one way to configure `article_parse_command` is to use [`mercury-parser`](https://github.com/postlight/mercury-parser#installation), a web parser tool that `hackernews_tui` has been using by default since the version `0.6.0`. `mercury-parser` is powerful and stable. However, in some cases, the text content it returns when parsing HTML `code` tags has some weird indentations.
 
-Another alternative is to use [`article_md`](https://github.com/aome510/article-md-cli), a CLI package I wrote for parsing article's content into a markdown format. Under the hood, it uses [mozilla's readability](https://github.com/mozilla/readability), so the parsed text content for the HTML `code` tags look nicer.
+An alternative is to use [`article_md`](https://github.com/aome510/article-md-cli), a CLI tool I wrote for parsing web article's content into a markdown format. Under the hood, it uses [mozilla's readability](https://github.com/mozilla/readability), so the parsed text for HTML `code` tags look nicer.
 
 ### User-defined shortcuts
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Another alternative is to use [`article_md`](https://github.com/aome510/article-
 
 ### User-defined shortcuts
 
-Shortcuts in each `View` are full customizable, for futher information about the supported keys and the corresponding functionalities, please refer to the **user-defined key bindings** sections in the example config file by running `hackernews_tui --example-config`.
+Shortcuts in each `View` are fully customizable, for further information about the supported keys and the corresponding functionalities, please refer to the **user-defined key bindings** sections in the example config file by running `hackernews_tui --example-config`.
 
 ### Custom Keymap
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ This application is the right tool for you :muscle:
 ### Table of Contents
 
 - [Install](#install)
-  - [Dependencies](#dependencies)
   - [Using Cargo](#using-cargo)
   - [Arch Linux](#arch-linux)
   - [NetBSD](#netbsd)
@@ -44,26 +43,13 @@ This application is the right tool for you :muscle:
     - [Comment View](#comment-view-shortcuts)
     - [Search View](#search-view-shortcuts)
 - [Configuration](#configuration)
+  - [Article Parse Command](#article-parse-command)
   - [User-defined shortcuts](#user-defined-shortcuts)
   - [Custom keymap](#custom-keymap)
 - [Debug](#debug)
 - [Roadmap](#roadmap)
 
 ## Install
-
-### Dependencies
-
-#### Mercury Parser
-
-To enable viewing a web page in reader mode with `Article View`, install [`mercury-parser`](https://github.com/postlight/mercury-parser) globally by running
-
-```shell
-# using yarn
-yarn global add @postlight/mercury-parser
-
-# or using npm
-npm install -g @postlight/mercury-parser
-```
 
 ### Using cargo
 
@@ -107,6 +93,7 @@ Run `yay -S hackernews_tui` to install the application as an AUR package.
 $ cd /usr/pkgsrc/www/hackernews-tui
 # make install
 ```
+
 
 ## Examples
 
@@ -241,6 +228,34 @@ hackernews_tui --example-config > ~/.config/hn-tui.toml
 ```
 
 then modify the config options in `~/.config/hn-tui.toml` based on your preferences.
+
+### Article Parse Command
+
+To enable viewing a web page in reader mode with `Article View`, you must configure the `article_parse_command` field in your configuration file:
+
+``` yaml
+# "article_parse_command" defines a command to parse a web article's content
+# to a markdown format. The parsed data is then used to render `ArticleView`
+# of the corresponding article.
+#
+# The command must have the following form:
+# [article_parse_command] [article_url] [options...]
+# It should return a JSON string representing the parsed Article data:
+# pub struct Article {
+#     title: String,
+#     url: String,
+#     content: String,
+#     author: Option<String>, // optional
+#     date_published: Option<String>, // optional
+#     word_count: usize, // optional
+# }
+article_parse_command = {command = "mercury-parser", options = ["--format", "markdown"]}
+# article_parse_command = {command = "article_md", options = []}
+```
+
+If you don't want to implement an article parser by your own, one way to configure `article_parse_command` is to use [`mercury-parser`](https://github.com/postlight/mercury-parser#installation), a web parser tool that `hackernews_tui` has been using by default since the version `0.6.0`. `mercury-parser` is powerful and stable. However, in some cases, the text content it returns when parsing HTML `code` tags has weird indentation.
+
+Another alternative is [`article-md-cli`](https://github.com/aome510/article-md-cli), a package I wrote for parsing article's content into a markdown format. Under the hood, it uses [mozilla's readability](https://github.com/mozilla/readability), so the parsed text content for the HTML `code` tags look nicer.
 
 ### User-defined shortcuts
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,12 +12,19 @@ pub struct Config {
     pub page_scrolling: bool,
     pub scroll_offset: usize,
     pub url_open_command: String,
+    pub article_parse_command: ArticleParseCommand,
 
     pub story_pooling: StoryPooling,
     pub client: Client,
     pub theme: Theme,
 
     pub keymap: KeyMap,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ArticleParseCommand {
+    pub command: String,
+    pub options: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -177,6 +184,10 @@ impl Default for Config {
             page_scrolling: true,
             scroll_offset: 3,
             url_open_command: "xdg-open".to_string(),
+            article_parse_command: ArticleParseCommand {
+                command: "mercury-parser".to_string(),
+                options: vec!["--format".to_string(), "markdown".to_string()],
+            },
             story_pooling: StoryPooling {
                 enable: true,
                 delay: 2,

--- a/src/hn-tui-default.toml
+++ b/src/hn-tui-default.toml
@@ -10,6 +10,24 @@ scroll_offset = 3
 # "url_open_command" is a terminal command used to open url in browser
 url_open_command = "xdg-open"
 
+# "article_parse_command" defines a command to parse a web article's content
+# to a markdown format. The parsed data is then used to render `ArticleView`
+# of the corresponding article.
+#
+# The command must have the following form:
+# [article_parse_command] [article_url] [options...]
+# It should return a JSON string representing the parsed Article data:
+# pub struct Article {
+#     title: String,
+#     url: String,
+#     content: String,
+#     author: Option<String>, // optional
+#     date_published: Option<String>, // optional
+#     word_count: usize, // optional
+# }
+article_parse_command = {command = "mercury-parser", options = ["--format", "markdown"]}
+# article_parse_command = {command = "article_md", options = []}
+
 [story_pooling]
 # "story_pooling" is a feature that allows the application to fetch stories
 # in background and store them in cache memory.

--- a/src/hn-tui-default.toml
+++ b/src/hn-tui-default.toml
@@ -15,7 +15,7 @@ url_open_command = "xdg-open"
 # of the corresponding article.
 #
 # The command must have the following form:
-# [article_parse_command] [article_url] [options...]
+# [article_parse_command] [options...] [article_url]
 # It should return a JSON string representing the parsed Article data:
 # pub struct Article {
 #     title: String,

--- a/src/view/async_view.rs
+++ b/src/view/async_view.rs
@@ -105,16 +105,18 @@ pub fn get_story_view_async(
 /// Return an async_view wrapping ArticleView with a loading screen when
 /// parsing the Article data
 pub fn get_article_view_async(siv: &mut Cursive, article_url: String) -> impl View {
+    let article_parse_command = get_config().article_parse_command.clone();
     let err_desc = format!(
-        "failed to execute command `mercury-parser --format markdown {}`:\n\
-         Please make sure you have `mercury-parser` installed in your path (https://github.com/aome510/hackernews-TUI#dependencies)",
+        "failed to execute command `{} {} {}`:\n\
+         Please make sure you configure `article_parse_command` as described in (https://github.com/aome510/hackernews-TUI#article-parse-command)",
+        article_parse_command.command,
+        article_parse_command.options.join(" "),
         article_url
     );
     AsyncView::new_with_bg_creator(
         siv,
         {
             let article_url = article_url.clone();
-            let article_parse_command = get_config().article_parse_command.clone();
             move || {
                 Ok(std::process::Command::new(article_parse_command.command)
                     .args(&article_parse_command.options)

--- a/src/view/async_view.rs
+++ b/src/view/async_view.rs
@@ -114,10 +114,10 @@ pub fn get_article_view_async(siv: &mut Cursive, article_url: String) -> impl Vi
         siv,
         {
             let article_url = article_url.clone();
+            let article_parse_command = get_config().article_parse_command.clone();
             move || {
-                Ok(std::process::Command::new("mercury-parser")
-                    .arg("--format")
-                    .arg("markdown")
+                Ok(std::process::Command::new(article_parse_command.command)
+                    .args(&article_parse_command.options)
                     .arg(&article_url)
                     .output())
             }


### PR DESCRIPTION
- allow defining custom article parser command besides the default `mercury-parser`
- handle invalid url when rendering `ArticleView`
- modify documentation about the parser for `ArticleView`