### PR TITLE
Add a client logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ List of demo videos:
 
 ## Default Shortcuts
 
-In each `View`, press `?` to see a list of supported keyboard shortcuts and their functionalities:
+In each `View`, press `?` to see a list of supported keyboard shortcuts and their functionalities. Note that the shortcuts are fully [customizable](#user-defined-shortcuts).
 
 ![Example of a Help View](https://raw.githubusercontent.com/aome510/hackernews-TUI/main/examples/assets/help_view.png)
 

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -36,10 +36,13 @@ impl CommentView {
     /// then update the internal comment data accordingly.
     pub fn try_update_comments(&mut self) {
         let mut new_comments = vec![];
-        while !self.receiver.is_empty() {
+        // limit the number of top comments updated each time
+        let mut limit = 5;
+        while !self.receiver.is_empty() && limit > 0 {
             if let Ok(mut comments) = self.receiver.try_recv() {
                 new_comments.append(&mut comments);
             }
+            limit -= 1;
         }
 
         if new_comments.is_empty() {


### PR DESCRIPTION
## Brief description of changes

- add a client logger to record API response time
- preserve the initial comment order in `Client::load_comments`
- limit the number of updated comments in each `CommentView::try_update_comments` call