### PR TITLE
Rewrite theme structs

### DIFF
--- a/examples/hn-tui.toml
+++ b/examples/hn-tui.toml
@@ -51,31 +51,7 @@
 # ---------------------------------
 
 #[theme]
-# cursive's palette colors
-# (more information can be found in https://docs.rs/cursive/0.16.3/cursive/theme/index.html)
-# background = "#f6f6ef"
-# shadow = "#000000"
-# view = "#f6f6ef"
-# primary = "#4a4a48"
-# secondary = "#a5a5a5"
-# tertiary = "#ffffff"
-# title_primary = "#000000"
-# title_secondary = "#ffff00"
-# highlight = "#6c6c6c"
-# highlight_inactive = "#0000ff"
-# highlight_text = "#c3bbbb"
-
-# additional colors defined by the application
-# `link_text` is a text color for a URL
-# `link_id` is a background color for `link_id` in CommentView
-# `search_highlight_bg` is a background color for matched search
-# `status_bar_bg` is a background color for the status bar
-# `code_block_bg` is a background color for a code block
-# link_text = "#4fbbfd"
-# link_id_bg = "#ffff00"
-# search_highlight_bg = "#ffff00"
-# status_bar_bg = "#ff6600"
-# code_block_bg = "#c8c8c8"
+# TODO: add default configuration settings for the application's theme
 
 # ---------------------------------
 # key bindings

--- a/hackernews_tui/src/client/parser.rs
+++ b/hackernews_tui/src/client/parser.rs
@@ -216,7 +216,7 @@ impl From<CommentResponse> for Vec<Comment> {
             text,
             minimized_text: StyledString::styled(
                 format!("{} ({} more)", base_desc, children.len() + 1,),
-                PaletteColor::Secondary,
+                config::get_config_theme().component_style.metadata,
             ),
             links,
         };
@@ -252,7 +252,8 @@ fn parse_raw_html_comment(text: &str, desc: &str) -> (StyledString, Vec<String>)
 
     // parse links in the comment, color them in the parsed text as well
     let mut links: Vec<String> = vec![];
-    let mut styled_s = StyledString::styled(desc, PaletteColor::Secondary);
+    let mut styled_s =
+        StyledString::styled(desc, config::get_config_theme().component_style.metadata);
     // replace the `<a href="${link}">...</a>` pattern one-by-one with "${link}".
     // cannot use `replace_all` because we want to replace a matched string with a `StyledString` (not a raw string)
     loop {

--- a/hackernews_tui/src/client/parser.rs
+++ b/hackernews_tui/src/client/parser.rs
@@ -277,14 +277,11 @@ fn parse_raw_html_comment(text: &str, desc: &str) -> (StyledString, Vec<String>)
 
                 styled_s.append_styled(
                     format!("\"{}\" ", utils::shorten_url(&link)),
-                    Style::from(config::get_config_theme().link_text.color),
+                    config::get_config_theme().component_style.link,
                 );
                 styled_s.append_styled(
                     format!("[{}]", links.len()),
-                    ColorStyle::new(
-                        PaletteColor::TitlePrimary,
-                        config::get_config_theme().link_id_bg.color,
-                    ),
+                    config::get_config_theme().component_style.link_id,
                 );
                 links.push(link);
                 continue;

--- a/hackernews_tui/src/config/mod.rs
+++ b/hackernews_tui/src/config/mod.rs
@@ -120,6 +120,8 @@ pub fn load_config(config_file_path: Option<&str>) {
         },
     };
 
+    tracing::info!("application's configurations: {:?}", config);
+
     init_config(config);
 }
 

--- a/hackernews_tui/src/config/theme.rs
+++ b/hackernews_tui/src/config/theme.rs
@@ -89,8 +89,8 @@ impl Default for ComponentStyle {
         Self {
             title_bar: ColorStyle::back(Color::parse("#ff6600")),
             link: ColorStyle::front(Color::parse("#4fbbfd")),
-            link_id: ColorStyle::back(Color::parse("light yellow")),
-            matched_highlight: ColorStyle::back(Color::parse("light yellow")),
+            link_id: ColorStyle::back(Color::parse("#ffff55")),
+            matched_highlight: ColorStyle::back(Color::parse("#ffff55")),
             code_block: ColorStyle::back(Color::parse("#c8c8c8")),
             metadata: ColorStyle::front(Color::parse("#a5a5a5")),
         }

--- a/hackernews_tui/src/config/theme.rs
+++ b/hackernews_tui/src/config/theme.rs
@@ -1,12 +1,13 @@
+use config_parser2::*;
 use serde::{de, Deserialize, Deserializer};
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, ConfigParse)]
 pub struct Theme {
     pub palette: Palette,
     pub component_style: ComponentStyle,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, ConfigParse)]
 pub struct Palette {
     pub background: Color,
     pub foreground: Color,
@@ -32,11 +33,13 @@ pub struct Palette {
     pub bright_yellow: Color,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, ConfigParse)]
 pub struct ComponentStyle {}
 
 #[derive(Clone, Debug)]
 pub struct Color(cursive::theme::Color);
+
+config_parser_impl!(Color);
 
 impl<'de> Deserialize<'de> for Color {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -49,4 +52,8 @@ impl<'de> Deserialize<'de> for Color {
             Some(color) => Ok(Color(color)),
         }
     }
+}
+
+pub fn get_config_theme() -> &'static Theme {
+    &super::get_config().theme
 }

--- a/hackernews_tui/src/config/theme.rs
+++ b/hackernews_tui/src/config/theme.rs
@@ -40,6 +40,7 @@ pub struct ComponentStyle {
     pub link_id: ColorStyle,
     pub matched_highlight: ColorStyle,
     pub code_block: ColorStyle,
+    pub metadata: ColorStyle,
 }
 
 impl Default for Palette {
@@ -79,6 +80,7 @@ impl Default for ComponentStyle {
             link_id: ColorStyle::back(Color::parse("#ffff00")),
             matched_highlight: ColorStyle::back(Color::parse("#ffff00")),
             code_block: ColorStyle::back(Color::parse("#c8c8c8")),
+            metadata: ColorStyle::front(Color::parse("#a5a5a5")),
         }
     }
 }
@@ -136,11 +138,23 @@ config_parser_impl!(Color);
 
 impl Color {
     pub fn try_parse(c: &str) -> Option<Self> {
-        cursive::theme::Color::parse(c).map(|c| Color(c))
+        cursive::theme::Color::parse(c).map(Color)
     }
 
     pub fn parse(c: &str) -> Self {
-        Self::try_parse(c).expect(&format!("failed to parse color: {}", c))
+        Self::try_parse(c).unwrap_or_else(|| panic!("failed to parse color: {}", c))
+    }
+}
+
+impl From<Color> for cursive::theme::Color {
+    fn from(c: Color) -> Self {
+        c.0
+    }
+}
+
+impl From<Color> for cursive::theme::Style {
+    fn from(c: Color) -> Self {
+        Self::from(cursive::theme::Color::from(c))
     }
 }
 

--- a/hackernews_tui/src/config/theme.rs
+++ b/hackernews_tui/src/config/theme.rs
@@ -3,12 +3,22 @@ use cursive::theme::BaseColor;
 use serde::{de, Deserialize, Deserializer};
 
 #[derive(Default, Clone, Copy, Debug, Deserialize, ConfigParse)]
+/// Application's theme, consists of two main parts:
+/// - a terminal color palette - `palette`
+/// - additional component styles - `component_style`
 pub struct Theme {
     pub palette: Palette,
     pub component_style: ComponentStyle,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, ConfigParse)]
+/// Terminal color palette.
+///
+/// This struct defines colors for application's background/foreground,
+/// selection text's background/foreground, and 16 ANSI colors.
+///
+/// The struct structure is compatible with the terminal color schemes as
+/// listed in https://github.com/mbadolato/iTerm2-Color-Schemes.
 pub struct Palette {
     pub background: Color,
     pub foreground: Color,
@@ -35,6 +45,7 @@ pub struct Palette {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, ConfigParse)]
+/// Additional colors/styles for specific components of the application.
 pub struct ComponentStyle {
     pub title_bar: ColorStyle,
     pub link: ColorStyle,

--- a/hackernews_tui/src/config/theme.rs
+++ b/hackernews_tui/src/config/theme.rs
@@ -1,103 +1,52 @@
-use config_parser2::*;
 use serde::{de, Deserialize, Deserializer};
 
-#[derive(Debug, Clone)]
-pub struct Color {
-    pub color: cursive::theme::Color,
+#[derive(Clone, Debug, Deserialize)]
+pub struct Theme {
+    pub palette: Palette,
+    pub component_style: ComponentStyle,
 }
 
-impl Color {
-    fn parse(s: &str) -> Option<Self> {
-        cursive::theme::Color::parse(s).map(|color| Color { color })
-    }
+#[derive(Clone, Debug, Deserialize)]
+pub struct Palette {
+    pub background: Color,
+    pub foreground: Color,
+    pub selection_background: Color,
+    pub selection_foreground: Color,
+
+    pub black: Color,
+    pub blue: Color,
+    pub cyan: Color,
+    pub green: Color,
+    pub magenta: Color,
+    pub red: Color,
+    pub white: Color,
+    pub yellow: Color,
+
+    pub bright_black: Color,
+    pub bright_white: Color,
+    pub bright_red: Color,
+    pub bright_magenta: Color,
+    pub bright_green: Color,
+    pub bright_cyan: Color,
+    pub bright_blue: Color,
+    pub bright_yellow: Color,
 }
 
-impl<'de> de::Deserialize<'de> for Color {
+#[derive(Clone, Debug, Deserialize)]
+pub struct ComponentStyle {}
+
+#[derive(Clone, Debug)]
+pub struct Color(cursive::theme::Color);
+
+impl<'de> Deserialize<'de> for Color {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        match Color::parse(&s) {
+        match cursive::theme::Color::parse(&s) {
             None => Err(de::Error::custom(format!("failed to parse color: {}", s))),
-            Some(color) => Ok(color),
+            Some(color) => Ok(Color(color)),
         }
     }
-}
-
-config_parser_impl!(Color);
-
-#[derive(Debug, Deserialize, Clone, ConfigParse)]
-pub struct Theme {
-    // cursive's palette colors
-    pub background: Color,
-    pub view: Color,
-    pub shadow: Color,
-    pub primary: Color,
-    pub secondary: Color,
-    pub tertiary: Color,
-    pub title_primary: Color,
-    pub title_secondary: Color,
-    pub highlight: Color,
-    pub highlight_inactive: Color,
-    pub highlight_text: Color,
-
-    // additional custom colors
-    pub link_text: Color,
-    pub link_id_bg: Color,
-    pub search_highlight_bg: Color,
-    pub status_bar_bg: Color,
-    pub code_block_bg: Color,
-}
-
-impl Theme {
-    pub fn update_theme(&self, theme: &mut cursive::theme::Theme) {
-        theme.palette.set_color("background", self.background.color);
-        theme.palette.set_color("view", self.view.color);
-        theme.palette.set_color("shadow", self.shadow.color);
-        theme.palette.set_color("primary", self.primary.color);
-        theme.palette.set_color("secondary", self.secondary.color);
-        theme.palette.set_color("tertiary", self.tertiary.color);
-        theme
-            .palette
-            .set_color("title_primary", self.title_primary.color);
-        theme
-            .palette
-            .set_color("title_secondary", self.title_secondary.color);
-        theme.palette.set_color("highlight", self.highlight.color);
-        theme
-            .palette
-            .set_color("highlight_inactive", self.highlight_inactive.color);
-        theme
-            .palette
-            .set_color("highlight_text", self.highlight_text.color);
-    }
-}
-
-impl Default for Theme {
-    fn default() -> Self {
-        Theme {
-            background: Color::parse("#f6f6ef").unwrap(),
-            shadow: Color::parse("#000000").unwrap(),
-            view: Color::parse("#f6f6ef").unwrap(),
-            primary: Color::parse("#4a4a48").unwrap(),
-            secondary: Color::parse("#a5a5a5").unwrap(),
-            tertiary: Color::parse("#ffffff").unwrap(),
-            title_primary: Color::parse("#000000").unwrap(),
-            title_secondary: Color::parse("#ffff00").unwrap(),
-            highlight: Color::parse("#6c6c6c").unwrap(),
-            highlight_inactive: Color::parse("#0000ff").unwrap(),
-            highlight_text: Color::parse("#c3bbbb").unwrap(),
-
-            link_text: Color::parse("#4fbbfd").unwrap(),
-            link_id_bg: Color::parse("#ffff00").unwrap(),
-            search_highlight_bg: Color::parse("#ffff00").unwrap(),
-            status_bar_bg: Color::parse("#ff6600").unwrap(),
-            code_block_bg: Color::parse("#c8c8c8").unwrap(),
-        }
-    }
-}
-
-pub fn get_config_theme() -> &'static Theme {
-    &super::get_config().theme
 }

--- a/hackernews_tui/src/config/theme.rs
+++ b/hackernews_tui/src/config/theme.rs
@@ -1,13 +1,13 @@
 use config_parser2::*;
 use serde::{de, Deserialize, Deserializer};
 
-#[derive(Clone, Debug, Deserialize, ConfigParse)]
+#[derive(Clone, Copy, Debug, Deserialize, ConfigParse)]
 pub struct Theme {
     pub palette: Palette,
     pub component_style: ComponentStyle,
 }
 
-#[derive(Clone, Debug, Deserialize, ConfigParse)]
+#[derive(Clone, Copy, Debug, Deserialize, ConfigParse)]
 pub struct Palette {
     pub background: Color,
     pub foreground: Color,
@@ -33,10 +33,34 @@ pub struct Palette {
     pub bright_yellow: Color,
 }
 
-#[derive(Clone, Debug, Deserialize, ConfigParse)]
-pub struct ComponentStyle {}
+#[derive(Clone, Copy, Debug, Deserialize, ConfigParse)]
+pub struct ComponentStyle {
+    pub title_bar: ColorStyle,
+    pub link: ColorStyle,
+    pub link_id: ColorStyle,
+    pub matched_highlight: ColorStyle,
+    pub code_block: ColorStyle,
+}
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, Deserialize, ConfigParse)]
+pub struct ColorStyle {
+    front: Color,
+    back: Color,
+}
+
+impl From<ColorStyle> for cursive::theme::ColorStyle {
+    fn from(c: ColorStyle) -> Self {
+        Self::new(c.front.0, c.back.0)
+    }
+}
+
+impl From<ColorStyle> for cursive::theme::Style {
+    fn from(c: ColorStyle) -> Self {
+        Self::from(cursive::theme::ColorStyle::from(c))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
 pub struct Color(cursive::theme::Color);
 
 config_parser_impl!(Color);

--- a/hackernews_tui/src/config/theme.rs
+++ b/hackernews_tui/src/config/theme.rs
@@ -1,4 +1,5 @@
 use config_parser2::*;
+use cursive::theme::BaseColor;
 use serde::{de, Deserialize, Deserializer};
 
 #[derive(Default, Clone, Copy, Debug, Deserialize, ConfigParse)]
@@ -23,14 +24,14 @@ pub struct Palette {
     pub white: Color,
     pub yellow: Color,
 
-    pub bright_black: Color,
-    pub bright_white: Color,
-    pub bright_red: Color,
-    pub bright_magenta: Color,
-    pub bright_green: Color,
-    pub bright_cyan: Color,
-    pub bright_blue: Color,
-    pub bright_yellow: Color,
+    pub light_black: Color,
+    pub light_white: Color,
+    pub light_red: Color,
+    pub light_magenta: Color,
+    pub light_green: Color,
+    pub light_cyan: Color,
+    pub light_blue: Color,
+    pub light_yellow: Color,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, ConfigParse)]
@@ -51,23 +52,23 @@ impl Default for Palette {
             selection_background: Color::parse("#6c6c6c"),
             selection_foreground: Color::parse("#c3bbbb"),
 
-            black: Color::parse("black"),
-            blue: Color::parse("blue"),
-            cyan: Color::parse("cyan"),
-            green: Color::parse("green"),
-            magenta: Color::parse("magenta"),
-            red: Color::parse("red"),
-            white: Color::parse("white"),
-            yellow: Color::parse("yellow"),
+            black: Color::parse("#000000"),
+            blue: Color::parse("#0000aa"),
+            cyan: Color::parse("#00aaaa"),
+            green: Color::parse("#00aa00"),
+            magenta: Color::parse("#aa00aa"),
+            red: Color::parse("#aa0000"),
+            white: Color::parse("#aaaaaa"),
+            yellow: Color::parse("#aaaa00"),
 
-            bright_black: Color::parse("light black"),
-            bright_white: Color::parse("light white"),
-            bright_red: Color::parse("light red"),
-            bright_magenta: Color::parse("light magenta"),
-            bright_green: Color::parse("light green"),
-            bright_cyan: Color::parse("light cyan"),
-            bright_blue: Color::parse("light blue"),
-            bright_yellow: Color::parse("light yellow"),
+            light_black: Color::parse("#555555"),
+            light_white: Color::parse("#ffffff"),
+            light_red: Color::parse("#ff5555"),
+            light_magenta: Color::parse("#5555ff"),
+            light_green: Color::parse("#55ff55"),
+            light_cyan: Color::parse("#55ffff"),
+            light_blue: Color::parse("#5555ff"),
+            light_yellow: Color::parse("#ffff55"),
         }
     }
 }
@@ -77,8 +78,8 @@ impl Default for ComponentStyle {
         Self {
             title_bar: ColorStyle::back(Color::parse("#ff6600")),
             link: ColorStyle::front(Color::parse("#4fbbfd")),
-            link_id: ColorStyle::back(Color::parse("#ffff00")),
-            matched_highlight: ColorStyle::back(Color::parse("#ffff00")),
+            link_id: ColorStyle::back(Color::parse("light yellow")),
+            matched_highlight: ColorStyle::back(Color::parse("light yellow")),
             code_block: ColorStyle::back(Color::parse("#c8c8c8")),
             metadata: ColorStyle::front(Color::parse("#a5a5a5")),
         }
@@ -117,9 +118,9 @@ impl ColorStyle {
 impl From<ColorStyle> for cursive::theme::ColorStyle {
     fn from(c: ColorStyle) -> Self {
         match (c.front, c.back) {
-            (Some(f), Some(b)) => Self::new(f.0, b.0),
-            (Some(f), None) => Self::front(f.0),
-            (None, Some(b)) => Self::back(b.0),
+            (Some(f), Some(b)) => Self::new(f, b),
+            (Some(f), None) => Self::front(f),
+            (None, Some(b)) => Self::back(b),
             (None, None) => Self::inherit_parent(),
         }
     }
@@ -148,7 +149,41 @@ impl Color {
 
 impl From<Color> for cursive::theme::Color {
     fn from(c: Color) -> Self {
-        c.0
+        // converts from application's color to `cursive::theme::color` will
+        // require to look into the application's pre-defined color palette.
+        //
+        // Under the hood, the application's palette colors are stored as a wrapper
+        // struct of `cursive::theme::color` (`Color`).
+        let palette = &get_config_theme().palette;
+        match c.0 {
+            Self::Dark(c) => match c {
+                BaseColor::Black => palette.black.0,
+                BaseColor::Red => palette.red.0,
+                BaseColor::Green => palette.green.0,
+                BaseColor::Yellow => palette.yellow.0,
+                BaseColor::Blue => palette.blue.0,
+                BaseColor::Magenta => palette.magenta.0,
+                BaseColor::Cyan => palette.cyan.0,
+                BaseColor::White => palette.white.0,
+            },
+            Self::Light(c) => match c {
+                BaseColor::Black => palette.light_black.0,
+                BaseColor::Red => palette.light_red.0,
+                BaseColor::Green => palette.light_green.0,
+                BaseColor::Yellow => palette.light_yellow.0,
+                BaseColor::Blue => palette.light_blue.0,
+                BaseColor::Magenta => palette.light_magenta.0,
+                BaseColor::Cyan => palette.light_cyan.0,
+                BaseColor::White => palette.light_white.0,
+            },
+            _ => c.0,
+        }
+    }
+}
+
+impl From<Color> for cursive::theme::ColorType {
+    fn from(c: Color) -> Self {
+        Self::from(cursive::theme::Color::from(c))
     }
 }
 

--- a/hackernews_tui/src/main.rs
+++ b/hackernews_tui/src/main.rs
@@ -82,12 +82,6 @@ fn set_up_global_callbacks(s: &mut Cursive, client: &'static client::HNClient) {
 fn run() {
     let mut s = cursive::default();
 
-    // update cursive's default theme
-    let config_theme = &config::get_config().theme;
-    s.update_theme(|theme| {
-        config_theme.update_theme(theme);
-    });
-
     // setup HN Client
     let client = client::init_client();
     set_up_global_callbacks(&mut s, client);

--- a/hackernews_tui/src/main.rs
+++ b/hackernews_tui/src/main.rs
@@ -82,6 +82,17 @@ fn set_up_global_callbacks(s: &mut Cursive, client: &'static client::HNClient) {
 fn run() {
     let mut s = cursive::default();
 
+    let theme = config::get_config_theme();
+    s.update_theme(|t| {
+        t.palette.set_color("view", theme.palette.background.into());
+        t.palette
+            .set_color("primary", theme.palette.foreground.into());
+        t.palette
+            .set_color("highlight", theme.palette.selection_background.into());
+        t.palette
+            .set_color("highlight_text", theme.palette.selection_foreground.into());
+    });
+
     // setup HN Client
     let client = client::init_client();
     set_up_global_callbacks(&mut s, client);

--- a/hackernews_tui/src/utils.rs
+++ b/hackernews_tui/src/utils.rs
@@ -56,12 +56,9 @@ pub fn shorten_url(url: &str) -> String {
 pub fn construct_footer_view<T: view::help_view::HasHelpView>() -> impl View {
     LinearLayout::horizontal()
         .child(
-            TextView::new(StyledString::styled(
-                "Hacker News Terminal UI - made by AOME ©",
-                ColorStyle::front(PaletteColor::TitlePrimary),
-            ))
-            .align(align::Align::bot_center())
-            .full_width(),
+            TextView::new("Hacker News Terminal UI - made by AOME ©")
+                .align(align::Align::bot_center())
+                .full_width(),
         )
         .child(
             LinearLayout::horizontal()

--- a/hackernews_tui/src/utils.rs
+++ b/hackernews_tui/src/utils.rs
@@ -73,19 +73,14 @@ pub fn construct_footer_view<T: view::help_view::HasHelpView>() -> impl View {
         )
 }
 
-/// Construct a status bar given a description text
-pub fn get_status_bar_with_desc(desc: &str) -> impl View {
+/// Construct a view's title bar
+pub fn construct_view_title_bar(desc: &str) -> impl View {
+    let style = config::get_config_theme().component_style.title_bar.into();
     Layer::with_color(
-        TextView::new(StyledString::styled(
-            desc,
-            ColorStyle::new(
-                PaletteColor::TitlePrimary,
-                config::get_config_theme().status_bar_bg.color,
-            ),
-        ))
-        .h_align(align::HAlign::Center)
-        .full_width(),
-        ColorStyle::back(config::get_config_theme().status_bar_bg.color),
+        TextView::new(StyledString::styled(desc, style))
+            .h_align(align::HAlign::Center)
+            .full_width(),
+        style,
     )
 }
 

--- a/hackernews_tui/src/view/article_view.rs
+++ b/hackernews_tui/src/view/article_view.rs
@@ -111,24 +111,15 @@ impl Article {
 
                     styled_s.append_styled(
                         format!("{} ", desc),
-                        Style::from(config::get_config_theme().link_text.color),
-                    );
-
-                    let valid_url = !link.is_empty();
-                    styled_s.append_styled(
-                        if valid_url {
-                            format!("[{}]", links.len())
-                        } else {
-                            "[X]".to_owned()
-                        },
-                        ColorStyle::new(
-                            PaletteColor::TitlePrimary,
-                            config::get_config_theme().link_id_bg.color,
-                        ),
+                        config::get_config_theme().component_style.link,
                     );
 
                     if !link.is_empty() {
-                        // valid url
+                        // a valid link
+                        styled_s.append_styled(
+                            format!("[{}]", links.len()),
+                            config::get_config_theme().component_style.link_id,
+                        );
                         links.push(link.to_string());
                     }
                     continue;
@@ -207,7 +198,7 @@ pub fn get_link_dialog(links: &[String]) -> impl View {
             let mut link_styled_string = StyledString::plain(format!("{}. ", id));
             link_styled_string.append_styled(
                 utils::shorten_url(link),
-                ColorStyle::front(config::get_config_theme().link_text.color),
+                config::get_config_theme().component_style.link,
             );
             v.add_child(text_view::TextView::new(link_styled_string));
         })
@@ -350,7 +341,7 @@ pub fn get_article_view(article: Article, raw_md: bool) -> impl View {
     let desc = format!("Article View - {}", article.title);
     let main_view = get_article_main_view(article.clone(), raw_md).full_height();
     let mut view = LinearLayout::vertical()
-        .child(utils::get_status_bar_with_desc(&desc))
+        .child(utils::construct_view_title_bar(&desc))
         .child(main_view)
         .child(utils::construct_footer_view::<ArticleView>());
     view.set_focus_index(1).unwrap_or_else(|_| {});

--- a/hackernews_tui/src/view/article_view.rs
+++ b/hackernews_tui/src/view/article_view.rs
@@ -160,18 +160,11 @@ impl ArticleView {
         );
 
         let view = LinearLayout::vertical()
-            .child(
-                TextView::new(StyledString::styled(
-                    title,
-                    ColorStyle::front(PaletteColor::TitlePrimary),
-                ))
-                .center()
-                .full_width(),
-            )
+            .child(TextView::new(title).center().full_width())
             .child(
                 TextView::new(StyledString::styled(
                     desc,
-                    ColorStyle::front(PaletteColor::Secondary),
+                    config::get_config_theme().component_style.metadata,
                 ))
                 .center()
                 .full_width(),

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -312,7 +312,7 @@ fn get_comment_main_view(receiver: client::CommentReceiver) -> impl View {
 
 /// Return a CommentView given a comment list and the discussed story's url/title
 pub fn get_comment_view(story: &client::Story, receiver: client::CommentReceiver) -> impl View {
-    let status_bar = utils::get_status_bar_with_desc(&format!("Comment View - {}", story.title));
+    let status_bar = utils::construct_view_title_bar(&format!("Comment View - {}", story.title));
 
     let main_view = get_comment_main_view(receiver);
 

--- a/hackernews_tui/src/view/error_view.rs
+++ b/hackernews_tui/src/view/error_view.rs
@@ -13,7 +13,7 @@ pub fn get_error_view(err_desc: &str, err_output: &str) -> impl View {
     .full_height();
 
     LinearLayout::vertical()
-        .child(utils::get_status_bar_with_desc("Error View"))
+        .child(utils::construct_view_title_bar("Error View"))
         .child(main_view)
         .child(utils::construct_footer_view::<help_view::DefaultHelpView>())
 }

--- a/hackernews_tui/src/view/help_view.rs
+++ b/hackernews_tui/src/view/help_view.rs
@@ -64,10 +64,7 @@ impl HelpView {
         LinearLayout::vertical()
             .with(|s| {
                 self.key_groups.iter().for_each(|(group_desc, keys)| {
-                    s.add_child(TextView::new(StyledString::styled(
-                        group_desc.to_string(),
-                        ColorStyle::from(PaletteColor::TitlePrimary),
-                    )));
+                    s.add_child(TextView::new(group_desc.to_string()));
                     s.add_child(HelpView::construct_keys_view(keys));
                 });
             })

--- a/hackernews_tui/src/view/help_view.rs
+++ b/hackernews_tui/src/view/help_view.rs
@@ -21,13 +21,8 @@ impl HelpView {
     }
 
     fn construct_key_view(key: String, desc: String, max_key_width: usize) -> impl View {
-        let key_string = StyledString::styled(
-            key,
-            ColorStyle::new(
-                PaletteColor::TitlePrimary,
-                config::get_config_theme().code_block_bg.color,
-            ),
-        );
+        let key_string =
+            StyledString::styled(key, config::get_config_theme().component_style.code_block);
         let desc_string = StyledString::plain(desc);
         LinearLayout::horizontal()
             .child(TextView::new(key_string).fixed_width(max_key_width))

--- a/hackernews_tui/src/view/search_view.rs
+++ b/hackernews_tui/src/view/search_view.rs
@@ -40,10 +40,7 @@ impl SearchView {
                 LinearLayout::horizontal()
                     .child(TextView::new(StyledString::styled(
                         "Search: ",
-                        ColorStyle::new(
-                            PaletteColor::TitlePrimary,
-                            config::get_config_theme().search_highlight_bg.color,
-                        ),
+                        config::get_config_theme().component_style.matched_highlight,
                     )))
                     .child(EditableTextView::new()),
             )
@@ -248,7 +245,7 @@ fn get_search_main_view(client: &'static client::HNClient, cb_sink: CbSink) -> i
 pub fn get_search_view(client: &'static client::HNClient, cb_sink: CbSink) -> impl View {
     let main_view = get_search_main_view(client, cb_sink);
     let mut view = LinearLayout::vertical()
-        .child(utils::get_status_bar_with_desc("Search View"))
+        .child(utils::construct_view_title_bar("Search View"))
         .child(main_view)
         .child(utils::construct_footer_view::<SearchView>());
     view.set_focus_index(1).unwrap_or_else(|_| {});

--- a/hackernews_tui/src/view/story_view.rs
+++ b/hackernews_tui/src/view/story_view.rs
@@ -66,10 +66,7 @@ impl StoryView {
 
                     styled_s.append_styled(
                         matched_text,
-                        ColorStyle::new(
-                            PaletteColor::TitlePrimary,
-                            config::get_config_theme().search_highlight_bg.color,
-                        ),
+                        config::get_config_theme().component_style.matched_highlight,
                     );
                     continue;
                 }
@@ -89,7 +86,7 @@ impl StoryView {
             let url = format!("\n{}", story.highlight_result.url);
             story_text.append(Self::get_matched_text(
                 url,
-                ColorStyle::front(config::get_config_theme().link_text.color),
+                config::get_config_theme().component_style.link.into(),
             ));
         }
         story_text.append_styled(
@@ -221,7 +218,7 @@ pub fn get_story_view(
     let main_view = get_story_main_view(stories, client, starting_id).full_height();
 
     let mut view = LinearLayout::vertical()
-        .child(utils::get_status_bar_with_desc(desc))
+        .child(utils::construct_view_title_bar(desc))
         .child(main_view)
         .child(utils::construct_footer_view::<StoryView>());
     view.set_focus_index(1).unwrap_or_else(|_| {});

--- a/hackernews_tui/src/view/story_view.rs
+++ b/hackernews_tui/src/view/story_view.rs
@@ -97,7 +97,7 @@ impl StoryView {
                 utils::get_elapsed_time_as_text(story.time),
                 story.num_comments,
             ),
-            ColorStyle::from(PaletteColor::Secondary),
+            config::get_config_theme().component_style.metadata,
         );
         story_text
     }


### PR DESCRIPTION
## Brief description of changes

- rewrote the application's theme structs using `Palette` and `ComponentStyle` structures
   - `Palette` defines the terminal color scheme for the application, so that it can be compatible with [other theme formats](https://github.com/mbadolato/iTerm2-Color-Schemes)
   - `ComponentStyle` defines additional colors, styles for specific components of the application
- wire up the new structs with the current application model to preserve the initial UI when using default configurations