### PR TITLE
Tweak application UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "unicode-width",
  "ureq",
  "url",
 ]

--- a/hackernews_tui/Cargo.toml
+++ b/hackernews_tui/Cargo.toml
@@ -35,3 +35,4 @@ url = "2.2.2"
 config_parser2 = { version = "0.1.2", path = "../config_parser" }
 crossbeam-channel = "0.5.1"
 lazy_static = "1.4.0"
+unicode-width = "0.1.9"

--- a/hackernews_tui/src/client/mod.rs
+++ b/hackernews_tui/src/client/mod.rs
@@ -80,6 +80,8 @@ impl HNClient {
 
         // loads first 5 comments to ensure the corresponding `CommentView` has data to render
         Self::load_comments(&client, &sender, &mut ids, 5)?;
+        // used to test loading bar
+        // std::thread::sleep(std::time::Duration::from_secs(1000));
         std::thread::spawn(move || {
             let sleep_dur = std::time::Duration::from_millis(1000);
             while !ids.is_empty() {

--- a/hackernews_tui/src/client/parser.rs
+++ b/hackernews_tui/src/client/parser.rs
@@ -201,23 +201,27 @@ impl From<CommentResponse> for Vec<Comment> {
             })
             .collect::<Vec<_>>();
 
-        let base_desc = format!(
-            "{} {} ago",
-            c.author.unwrap_or_default(),
-            utils::get_elapsed_time_as_text(c.time),
-        );
-        let (text, links) =
-            parse_raw_html_comment(&c.text.unwrap_or_default(), &format!("{}\n", base_desc));
+        let metadata = utils::combine_styled_string(vec![
+            StyledString::styled(c.author.unwrap_or_default(), Style::from(Effect::Bold)),
+            StyledString::styled(
+                format!(" {} ago ", utils::get_elapsed_time_as_text(c.time)),
+                config::get_config_theme().component_style.metadata,
+            ),
+        ]);
+        let (text, links) = parse_raw_html_comment(&c.text.unwrap_or_default(), metadata.clone());
 
         let comment = Comment {
             id: c.id,
             height: 0,
             state: CommentState::Normal,
             text,
-            minimized_text: StyledString::styled(
-                format!("{} ({} more)", base_desc, children.len() + 1,),
-                config::get_config_theme().component_style.metadata,
-            ),
+            minimized_text: utils::combine_styled_string(vec![
+                metadata,
+                StyledString::styled(
+                    format!("({} more)", children.len() + 1),
+                    Style::from(Effect::Reverse),
+                ),
+            ]),
             links,
         };
 
@@ -236,7 +240,7 @@ fn decode_html(s: &str) -> String {
 /// The function returns the parsed text and a vector of links in the comment.
 ///
 /// Links inside the parsed text are colored.
-fn parse_raw_html_comment(text: &str, desc: &str) -> (StyledString, Vec<String>) {
+fn parse_raw_html_comment(text: &str, metadata: StyledString) -> (StyledString, Vec<String>) {
     // insert newlines as a separator between paragraphs
     let mut s = PARAGRAPH_RE
         .replace_all(text, "${paragraph}\n\n")
@@ -250,10 +254,12 @@ fn parse_raw_html_comment(text: &str, desc: &str) -> (StyledString, Vec<String>)
     s = ITALIC_RE.replace_all(&s, "*${text}*").to_string();
     s = CODE_RE.replace_all(&s, "```\n${code}\n```").to_string();
 
+    let mut result = metadata;
+    result.append_plain("\n");
+
     // parse links in the comment, color them in the parsed text as well
     let mut links: Vec<String> = vec![];
-    let mut styled_s =
-        StyledString::styled(desc, config::get_config_theme().component_style.metadata);
+
     // replace the `<a href="${link}">...</a>` pattern one-by-one with "${link}".
     // cannot use `replace_all` because we want to replace a matched string with a `StyledString` (not a raw string)
     loop {
@@ -273,14 +279,14 @@ fn parse_raw_html_comment(text: &str, desc: &str) -> (StyledString, Vec<String>)
                 prefix.drain(range);
 
                 if !prefix.is_empty() {
-                    styled_s.append_plain(decode_html(&prefix));
+                    result.append_plain(decode_html(&prefix));
                 }
 
-                styled_s.append_styled(
+                result.append_styled(
                     format!("\"{}\" ", utils::shorten_url(&link)),
                     config::get_config_theme().component_style.link,
                 );
-                styled_s.append_styled(
+                result.append_styled(
                     format!("[{}]", links.len()),
                     config::get_config_theme().component_style.link_id,
                 );
@@ -290,7 +296,7 @@ fn parse_raw_html_comment(text: &str, desc: &str) -> (StyledString, Vec<String>)
         }
     }
     if !s.is_empty() {
-        styled_s.append_plain(decode_html(&s));
+        result.append_plain(decode_html(&s));
     }
-    (styled_s, links)
+    (result, links)
 }

--- a/hackernews_tui/src/client/parser.rs
+++ b/hackernews_tui/src/client/parser.rs
@@ -201,8 +201,11 @@ impl From<CommentResponse> for Vec<Comment> {
             })
             .collect::<Vec<_>>();
 
-        let metadata = utils::combine_styled_string(vec![
-            StyledString::styled(c.author.unwrap_or_default(), Style::from(Effect::Bold)),
+        let metadata = utils::combine_styled_strings(vec![
+            StyledString::styled(
+                c.author.unwrap_or_default(),
+                config::get_config_theme().component_style.username,
+            ),
             StyledString::styled(
                 format!(" {} ago ", utils::get_elapsed_time_as_text(c.time)),
                 config::get_config_theme().component_style.metadata,
@@ -215,11 +218,11 @@ impl From<CommentResponse> for Vec<Comment> {
             height: 0,
             state: CommentState::Normal,
             text,
-            minimized_text: utils::combine_styled_string(vec![
+            minimized_text: utils::combine_styled_strings(vec![
                 metadata,
                 StyledString::styled(
                     format!("({} more)", children.len() + 1),
-                    Style::from(Effect::Reverse),
+                    config::get_config_theme().component_style.metadata,
                 ),
             ]),
             links,

--- a/hackernews_tui/src/config/keybindings.rs
+++ b/hackernews_tui/src/config/keybindings.rs
@@ -74,12 +74,12 @@ impl Default for GlobalKeyMap {
             close_dialog: Key::new(event::Key::Esc),
 
             goto_previous_view: Key::new(event::Event::CtrlChar('p')),
-            goto_front_page_view: Key::new(event::Event::CtrlChar('f')),
             goto_search_view: Key::new(event::Event::CtrlChar('s')),
-            goto_all_stories_view: Key::new(event::Event::CtrlChar('z')),
-            goto_ask_hn_view: Key::new(event::Event::CtrlChar('x')),
-            goto_show_hn_view: Key::new(event::Event::CtrlChar('c')),
-            goto_jobs_view: Key::new(event::Event::CtrlChar('v')),
+            goto_front_page_view: Key::new(event::Key::F1),
+            goto_all_stories_view: Key::new(event::Key::F2),
+            goto_ask_hn_view: Key::new(event::Key::F3),
+            goto_show_hn_view: Key::new(event::Key::F4),
+            goto_jobs_view: Key::new(event::Key::F5),
         }
     }
 }

--- a/hackernews_tui/src/config/mod.rs
+++ b/hackernews_tui/src/config/mod.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 /// Config is a struct storing the application's configurations
 pub struct Config {
     pub page_scrolling: bool,
+    pub use_pacman_loading: bool,
     pub url_open_command: String,
     pub article_parse_command: ArticleParseCommand,
     pub client: Client,
@@ -35,6 +36,7 @@ impl Default for Config {
     fn default() -> Self {
         Config {
             page_scrolling: true,
+            use_pacman_loading: true,
             url_open_command: "open".to_string(),
             article_parse_command: ArticleParseCommand {
                 command: "mercury-parser".to_string(),

--- a/hackernews_tui/src/config/theme.rs
+++ b/hackernews_tui/src/config/theme.rs
@@ -89,8 +89,8 @@ impl Default for ComponentStyle {
         Self {
             title_bar: ColorStyle::new(Color::parse("black"), Color::parse("#ff6600")),
             link: ColorStyle::front(Color::parse("#4fbbfd")),
-            link_id: ColorStyle::back(Color::parse("#ffff55")),
-            matched_highlight: ColorStyle::back(Color::parse("#ffff55")),
+            link_id: ColorStyle::new(Color::parse("black"), Color::parse("#ffff55")),
+            matched_highlight: ColorStyle::new(Color::parse("black"), Color::parse("#ffff55")),
             code_block: ColorStyle::back(Color::parse("#c8c8c8")),
             metadata: ColorStyle::front(Color::parse("#a5a5a5")),
         }

--- a/hackernews_tui/src/config/theme.rs
+++ b/hackernews_tui/src/config/theme.rs
@@ -59,9 +59,9 @@ impl Default for Palette {
     fn default() -> Self {
         Self {
             background: Color::parse("#f6f6ef"),
-            foreground: Color::parse("#4a4a48"),
-            selection_background: Color::parse("#6c6c6c"),
-            selection_foreground: Color::parse("#c3bbbb"),
+            foreground: Color::parse("#242424"),
+            selection_background: Color::parse("#d8dad6"),
+            selection_foreground: Color::parse("#4a4c4c"),
 
             black: Color::parse("#000000"),
             blue: Color::parse("#0000aa"),
@@ -91,8 +91,8 @@ impl Default for ComponentStyle {
             link: ColorStyle::front(Color::parse("#4fbbfd")),
             link_id: ColorStyle::new(Color::parse("black"), Color::parse("#ffff55")),
             matched_highlight: ColorStyle::new(Color::parse("black"), Color::parse("#ffff55")),
-            code_block: ColorStyle::back(Color::parse("#c8c8c8")),
-            metadata: ColorStyle::front(Color::parse("#a5a5a5")),
+            code_block: ColorStyle::new(Color::parse("black"), Color::parse("#c8c8c8")),
+            metadata: ColorStyle::front(Color::parse("#828282")),
         }
     }
 }

--- a/hackernews_tui/src/config/theme.rs
+++ b/hackernews_tui/src/config/theme.rs
@@ -47,12 +47,16 @@ pub struct Palette {
 #[derive(Clone, Copy, Debug, Deserialize, ConfigParse)]
 /// Additional colors/styles for specific components of the application.
 pub struct ComponentStyle {
-    pub title_bar: ColorStyle,
-    pub link: ColorStyle,
-    pub link_id: ColorStyle,
-    pub matched_highlight: ColorStyle,
-    pub code_block: ColorStyle,
-    pub metadata: ColorStyle,
+    pub title: Style,
+    pub title_bar: Style,
+    pub link: Style,
+    pub link_id: Style,
+    pub matched_highlight: Style,
+    pub code_block: Style,
+    pub metadata: Style,
+    pub current_story_tag: Style,
+    pub username: Style,
+    pub loading_bar: Style,
 }
 
 impl Default for Palette {
@@ -87,47 +91,62 @@ impl Default for Palette {
 impl Default for ComponentStyle {
     fn default() -> Self {
         Self {
-            title_bar: ColorStyle::new(Color::parse("black"), Color::parse("#ff6600")),
-            link: ColorStyle::front(Color::parse("#4fbbfd")),
-            link_id: ColorStyle::new(Color::parse("black"), Color::parse("#ffff55")),
-            matched_highlight: ColorStyle::new(Color::parse("black"), Color::parse("#ffff55")),
-            code_block: ColorStyle::new(Color::parse("black"), Color::parse("#c8c8c8")),
-            metadata: ColorStyle::front(Color::parse("#828282")),
+            title: Style::default().effect(Effect::Bold),
+            title_bar: Style::default()
+                .back(Color::parse("#ff6600"))
+                .effect(Effect::Bold),
+            current_story_tag: Style::default().front(Color::parse("light white")),
+            link: Style::default().front(Color::parse("#4fbbfd")),
+            link_id: Style::default()
+                .front(Color::parse("black"))
+                .back(Color::parse("#ffff55")),
+            matched_highlight: Style::default()
+                .front(Color::parse("black"))
+                .back(Color::parse("#ffff55")),
+            code_block: Style::default()
+                .front(Color::parse("black"))
+                .back(Color::parse("#c8c8c8")),
+            metadata: Style::default().front(Color::parse("#828282")),
+            username: Style::default().effect(Effect::Bold),
+            loading_bar: Style::default()
+                .front(Color::parse("light yellow"))
+                .back(Color::parse("blue")),
         }
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize)]
-pub struct ColorStyle {
+#[derive(Default, Clone, Copy, Debug, Deserialize)]
+pub struct Style {
     front: Option<Color>,
     back: Option<Color>,
+    effect: Option<Effect>,
 }
 
-config_parser_impl!(ColorStyle);
+config_parser_impl!(Style);
 
-impl ColorStyle {
-    pub fn new(f: Color, b: Color) -> Self {
-        Self {
-            front: Some(f),
-            back: Some(b),
-        }
-    }
-    pub fn front(c: Color) -> Self {
+impl Style {
+    pub fn front(self, c: Color) -> Self {
         Self {
             front: Some(c),
-            back: None,
+            ..self
         }
     }
-    pub fn back(c: Color) -> Self {
+    pub fn back(self, c: Color) -> Self {
         Self {
-            front: None,
             back: Some(c),
+            ..self
+        }
+    }
+    pub fn effect(self, e: Effect) -> Self {
+        Self {
+            effect: Some(e),
+            ..self
         }
     }
 }
 
-impl From<ColorStyle> for cursive::theme::ColorStyle {
-    fn from(c: ColorStyle) -> Self {
+impl From<Style> for cursive::theme::ColorStyle {
+    fn from(c: Style) -> Self {
         match (c.front, c.back) {
             (Some(f), Some(b)) => Self::new(f, b),
             (Some(f), None) => Self::front(f),
@@ -137,9 +156,13 @@ impl From<ColorStyle> for cursive::theme::ColorStyle {
     }
 }
 
-impl From<ColorStyle> for cursive::theme::Style {
-    fn from(c: ColorStyle) -> Self {
-        Self::from(cursive::theme::ColorStyle::from(c))
+impl From<Style> for cursive::theme::Style {
+    fn from(c: Style) -> Self {
+        let style = Self::from(cursive::theme::ColorStyle::from(c));
+        match c.effect {
+            None => style,
+            Some(e) => style.combine(cursive::theme::Effect::from(e)),
+        }
     }
 }
 
@@ -223,6 +246,33 @@ impl<'de> Deserialize<'de> for Color {
         match Self::try_parse(&s) {
             None => Err(de::Error::custom(format!("failed to parse color: {}", s))),
             Some(color) => Ok(color),
+        }
+    }
+}
+
+// A copy struct of `cursive::theme::Effect` that
+// derives serde::Deserialize
+#[derive(Deserialize, Debug, Clone, Copy)]
+pub enum Effect {
+    Simple,
+    Reverse,
+    Bold,
+    Italic,
+    Strikethrough,
+    Underline,
+    Blink,
+}
+
+impl From<Effect> for cursive::theme::Effect {
+    fn from(e: Effect) -> Self {
+        match e {
+            Effect::Simple => Self::Simple,
+            Effect::Reverse => Self::Reverse,
+            Effect::Bold => Self::Bold,
+            Effect::Italic => Self::Italic,
+            Effect::Strikethrough => Self::Strikethrough,
+            Effect::Underline => Self::Underline,
+            Effect::Blink => Self::Blink,
         }
     }
 }

--- a/hackernews_tui/src/config/theme.rs
+++ b/hackernews_tui/src/config/theme.rs
@@ -87,7 +87,7 @@ impl Default for Palette {
 impl Default for ComponentStyle {
     fn default() -> Self {
         Self {
-            title_bar: ColorStyle::back(Color::parse("#ff6600")),
+            title_bar: ColorStyle::new(Color::parse("black"), Color::parse("#ff6600")),
             link: ColorStyle::front(Color::parse("#4fbbfd")),
             link_id: ColorStyle::back(Color::parse("#ffff55")),
             matched_highlight: ColorStyle::back(Color::parse("#ffff55")),

--- a/hackernews_tui/src/config/theme.rs
+++ b/hackernews_tui/src/config/theme.rs
@@ -149,12 +149,22 @@ pub struct Color(cursive::theme::Color);
 config_parser_impl!(Color);
 
 impl Color {
+    pub fn new(c: cursive::theme::Color) -> Self {
+        Self(c)
+    }
+
     pub fn try_parse(c: &str) -> Option<Self> {
         cursive::theme::Color::parse(c).map(Color)
     }
 
     pub fn parse(c: &str) -> Self {
         Self::try_parse(c).unwrap_or_else(|| panic!("failed to parse color: {}", c))
+    }
+}
+
+impl From<u8> for Color {
+    fn from(x: u8) -> Self {
+        Self(cursive::theme::Color::from_256colors(x))
     }
 }
 

--- a/hackernews_tui/src/main.rs
+++ b/hackernews_tui/src/main.rs
@@ -88,6 +88,8 @@ fn run() {
         t.palette
             .set_color("primary", theme.palette.foreground.into());
         t.palette
+            .set_color("title_primary", theme.palette.foreground.into());
+        t.palette
             .set_color("highlight", theme.palette.selection_background.into());
         t.palette
             .set_color("highlight_text", theme.palette.selection_foreground.into());

--- a/hackernews_tui/src/utils.rs
+++ b/hackernews_tui/src/utils.rs
@@ -56,9 +56,12 @@ pub fn shorten_url(url: &str) -> String {
 pub fn construct_footer_view<T: view::help_view::HasHelpView>() -> impl View {
     LinearLayout::horizontal()
         .child(
-            TextView::new("Hacker News Terminal UI - made by AOME ©")
-                .align(align::Align::bot_center())
-                .full_width(),
+            TextView::new(StyledString::styled(
+                "Hacker News Terminal UI - made by AOME ©",
+                Style::from(Effect::Bold),
+            ))
+            .align(align::Align::bot_center())
+            .full_width(),
         )
         .child(
             LinearLayout::horizontal()
@@ -82,9 +85,12 @@ pub fn combine_styled_string(strings: Vec<StyledString>) -> StyledString {
 pub fn construct_view_title_bar(desc: &str) -> impl View {
     let style = config::get_config_theme().component_style.title_bar.into();
     Layer::with_color(
-        TextView::new(StyledString::styled(desc, style))
-            .h_align(align::HAlign::Center)
-            .full_width(),
+        TextView::new(StyledString::styled(
+            desc,
+            Style::from(style).combine(Style::from(Effect::Bold)),
+        ))
+        .h_align(align::HAlign::Center)
+        .full_width(),
         style,
     )
 }

--- a/hackernews_tui/src/utils.rs
+++ b/hackernews_tui/src/utils.rs
@@ -58,7 +58,7 @@ pub fn construct_footer_view<T: view::help_view::HasHelpView>() -> impl View {
         .child(
             TextView::new(StyledString::styled(
                 "Hacker News Terminal UI - made by AOME ©",
-                Style::from(Effect::Bold),
+                config::get_config_theme().component_style.title,
             ))
             .align(align::Align::bot_center())
             .full_width(),
@@ -74,7 +74,7 @@ pub fn construct_footer_view<T: view::help_view::HasHelpView>() -> impl View {
 }
 
 /// Combine multiple styled strings into a single styled string
-pub fn combine_styled_string(strings: Vec<StyledString>) -> StyledString {
+pub fn combine_styled_strings(strings: Vec<StyledString>) -> StyledString {
     strings.into_iter().fold(StyledString::new(), |mut acc, s| {
         acc.append(s);
         acc
@@ -83,15 +83,12 @@ pub fn combine_styled_string(strings: Vec<StyledString>) -> StyledString {
 
 /// Construct a view's title bar
 pub fn construct_view_title_bar(desc: &str) -> impl View {
-    let style = config::get_config_theme().component_style.title_bar.into();
+    let style = config::get_config_theme().component_style.title_bar;
     Layer::with_color(
-        TextView::new(StyledString::styled(
-            desc,
-            Style::from(style).combine(Style::from(Effect::Bold)),
-        ))
-        .h_align(align::HAlign::Center)
-        .full_width(),
-        style,
+        TextView::new(StyledString::styled(desc, style))
+            .h_align(align::HAlign::Center)
+            .full_width(),
+        style.into(),
     )
 }
 

--- a/hackernews_tui/src/utils.rs
+++ b/hackernews_tui/src/utils.rs
@@ -81,21 +81,6 @@ pub fn construct_view_title_bar(desc: &str) -> impl View {
     )
 }
 
-/// Construct StoryView based on the filtering tag
-pub fn get_story_view_desc_by_tag(tag: &str) -> String {
-    format!(
-        "Story View - {}",
-        match tag {
-            "front_page" => "Front Page",
-            "story" => "All Stories",
-            "job" => "Jobs",
-            "ask_hn" => "Ask HN",
-            "show_hn" => "Show HN",
-            _ => panic!("unknown tag: {}", tag),
-        },
-    )
-}
-
 /// open a given url using a specific command
 pub fn open_url_in_browser(url: &str) {
     if url.is_empty() {

--- a/hackernews_tui/src/utils.rs
+++ b/hackernews_tui/src/utils.rs
@@ -70,6 +70,14 @@ pub fn construct_footer_view<T: view::help_view::HasHelpView>() -> impl View {
         )
 }
 
+/// Combine multiple styled strings into a single styled string
+pub fn combine_styled_string(strings: Vec<StyledString>) -> StyledString {
+    strings.into_iter().fold(StyledString::new(), |mut acc, s| {
+        acc.append(s);
+        acc
+    })
+}
+
 /// Construct a view's title bar
 pub fn construct_view_title_bar(desc: &str) -> impl View {
     let style = config::get_config_theme().component_style.title_bar.into();

--- a/hackernews_tui/src/view/async_view.rs
+++ b/hackernews_tui/src/view/async_view.rs
@@ -44,7 +44,6 @@ pub fn get_story_view_async(
         move |result| {
             ErrorViewWrapper::new(match result {
                 Ok(stories) => ErrorViewEnum::Ok(story_view::get_story_view(
-                    &utils::get_story_view_desc_by_tag(tag),
                     stories,
                     client,
                     tag,

--- a/hackernews_tui/src/view/async_view.rs
+++ b/hackernews_tui/src/view/async_view.rs
@@ -133,16 +133,17 @@ pub fn get_article_view_async(siv: &mut Cursive, article_url: &str) -> impl View
 }
 
 fn animation(width: usize, _height: usize, frame_idx: usize) -> cursive_async_view::AnimationFrame {
-    let n_frames = 60; // number of frames to complete an animation
+    let n_frames = 120; // number of frames to complete an animation
+    let style = ColorStyle::from(config::get_config_theme().component_style.loading_bar);
 
     if config::get_config().use_pacman_loading {
         let factor = (frame_idx as f64) / (n_frames as f64);
         let x = (factor * width as f64) as usize;
 
-        let content = utils::combine_styled_string(vec![
-            StyledString::plain(repeat_str("- ", x / 2)),
-            StyledString::plain('ᗧ'),
-            StyledString::plain(repeat_str(" o", width.saturating_sub(x + 1) / 2)),
+        let content = utils::combine_styled_strings(vec![
+            StyledString::styled(repeat_str("- ", x / 2), style),
+            StyledString::styled('ᗧ', style),
+            StyledString::styled(repeat_str(" o", width.saturating_sub(x + 1) / 2), style),
         ]);
 
         cursive_async_view::AnimationFrame {
@@ -150,34 +151,18 @@ fn animation(width: usize, _height: usize, frame_idx: usize) -> cursive_async_vi
             next_frame_idx: (frame_idx + 1) % n_frames,
         }
     } else {
-        // a simple loading screen with colors,
-        // this animation function will swap the background/foreground colors of
-        // the loading bar after completing an animation.
-
         let symbol = "━";
-        let (foreground, background) = if frame_idx < 60 {
-            (
-                config::Color::new(Color::Dark(BaseColor::Black)),
-                config::Color::new(Color::Dark(BaseColor::White)),
-            )
-        } else {
-            (
-                config::Color::new(Color::Dark(BaseColor::White)),
-                config::Color::new(Color::Dark(BaseColor::Black)),
-            )
-        };
-
-        let factor = ((frame_idx % n_frames) as f64) / (n_frames as f64);
+        let factor = (frame_idx as f64) / (n_frames as f64);
         let x = (factor * width as f64) as usize;
 
-        let content = utils::combine_styled_string(vec![
-            StyledString::styled(repeat_str(symbol, x), foreground),
-            StyledString::styled(repeat_str(symbol, width - x), background),
+        let content = utils::combine_styled_strings(vec![
+            StyledString::styled(repeat_str(symbol, x), style.back),
+            StyledString::styled(repeat_str(symbol, width - x), style.front),
         ]);
 
         cursive_async_view::AnimationFrame {
             content,
-            next_frame_idx: (frame_idx + 1) % (2 * n_frames),
+            next_frame_idx: (frame_idx + 1) % n_frames,
         }
     }
 }

--- a/hackernews_tui/src/view/async_view.rs
+++ b/hackernews_tui/src/view/async_view.rs
@@ -25,6 +25,7 @@ pub fn get_comment_view_async(
             })
         }
     })
+    .with_animation_fn(animation)
     .align_center()
     .full_screen()
 }
@@ -61,6 +62,7 @@ pub fn get_story_view_async(
             })
         },
     )
+    .with_animation_fn(animation)
     .align_center()
     .full_screen()
 }
@@ -125,6 +127,61 @@ pub fn get_article_view_async(siv: &mut Cursive, article_url: &str) -> impl View
             }
         },
     )
+    .with_animation_fn(animation)
     .align_center()
     .full_screen()
+}
+
+fn animation(width: usize, _height: usize, frame_idx: usize) -> cursive_async_view::AnimationFrame {
+    let n_frames = 60; // number of frames to complete an animation
+
+    if config::get_config().use_pacman_loading {
+        let factor = (frame_idx as f64) / (n_frames as f64);
+        let x = (factor * width as f64) as usize;
+
+        let content = utils::combine_styled_string(vec![
+            StyledString::plain(repeat_str("- ", x / 2)),
+            StyledString::plain('ᗧ'),
+            StyledString::plain(repeat_str(" o", width.saturating_sub(x + 1) / 2)),
+        ]);
+
+        cursive_async_view::AnimationFrame {
+            content,
+            next_frame_idx: (frame_idx + 1) % n_frames,
+        }
+    } else {
+        // a simple loading screen with colors,
+        // this animation function will swap the background/foreground colors of
+        // the loading bar after completing an animation.
+
+        let symbol = "━";
+        let (foreground, background) = if frame_idx < 60 {
+            (
+                config::Color::new(Color::Dark(BaseColor::Black)),
+                config::Color::new(Color::Dark(BaseColor::White)),
+            )
+        } else {
+            (
+                config::Color::new(Color::Dark(BaseColor::White)),
+                config::Color::new(Color::Dark(BaseColor::Black)),
+            )
+        };
+
+        let factor = ((frame_idx % n_frames) as f64) / (n_frames as f64);
+        let x = (factor * width as f64) as usize;
+
+        let content = utils::combine_styled_string(vec![
+            StyledString::styled(repeat_str(symbol, x), foreground),
+            StyledString::styled(repeat_str(symbol, width - x), background),
+        ]);
+
+        cursive_async_view::AnimationFrame {
+            content,
+            next_frame_idx: (frame_idx + 1) % (2 * n_frames),
+        }
+    }
+}
+
+fn repeat_str<S: Into<String>>(s: S, n: usize) -> String {
+    s.into().repeat(n)
 }

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -3,6 +3,8 @@ use super::list_view::*;
 use super::text_view;
 use super::{article_view, async_view};
 use crate::prelude::*;
+use crate::view::text_view::StyledPaddingChar;
+use crate::view::text_view::TextPadding;
 
 type CommentComponent = HideableView<PaddedView<text_view::TextView>>;
 
@@ -50,12 +52,24 @@ impl CommentView {
         }
 
         new_comments.iter().for_each(|comment| {
+            let text_view = text_view::TextView::new(comment.text.clone());
             self.add_item(HideableView::new(PaddedView::lrtb(
-                comment.height * 2,
-                0,
+                comment.height * 2 + 1,
+                1,
                 0,
                 1,
-                text_view::TextView::new(comment.text.clone()),
+                if comment.height > 0 {
+                    // get the padding style (color) based on the comment's height
+                    //
+                    // We use base 16 colors to display the comment's padding
+                    let c = config::Color::from((comment.height % 16) as u8);
+                    text_view
+                        .padding(TextPadding::default().left(StyledPaddingChar::new('▎', c.into())))
+                } else {
+                    let c = config::Color::new(Color::Dark(BaseColor::White));
+                    text_view
+                        .padding(TextPadding::default().top(StyledPaddingChar::new('▔', c.into())))
+                },
             )));
         });
         self.comments.append(&mut new_comments);

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -66,8 +66,8 @@ impl CommentView {
                     text_view
                         .padding(TextPadding::default().left(StyledPaddingChar::new('▎', c.into())))
                 } else {
-                    // add top padding for top comments
-                    let c = config::Color::new(Color::Dark(BaseColor::White));
+                    // add top padding for top comments, use the first color in the 16 base colors
+                    let c = config::Color::from(0);
                     text_view
                         .padding(TextPadding::default().top(StyledPaddingChar::new('▔', c.into())))
                 },

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -66,6 +66,7 @@ impl CommentView {
                     text_view
                         .padding(TextPadding::default().left(StyledPaddingChar::new('▎', c.into())))
                 } else {
+                    // add top padding for top comments
                     let c = config::Color::new(Color::Dark(BaseColor::White));
                     text_view
                         .padding(TextPadding::default().top(StyledPaddingChar::new('▔', c.into())))

--- a/hackernews_tui/src/view/help_view.rs
+++ b/hackernews_tui/src/view/help_view.rs
@@ -131,8 +131,8 @@ macro_rules! view_navigation_key_shortcuts {
                     ($k, $d),
                 )*
                     (config::get_global_keymap().goto_previous_view.to_string(), "Go to the previous view"),
-                    (config::get_global_keymap().goto_front_page_view.to_string(), "Go to front page view"),
                     (config::get_global_keymap().goto_search_view.to_string(), "Go to search view"),
+                    (config::get_global_keymap().goto_front_page_view.to_string(), "Go to front page view"),
                     (config::get_global_keymap().goto_all_stories_view.to_string(), "Go to all stories view"),
                     (config::get_global_keymap().goto_ask_hn_view.to_string(), "Go to ask HN view"),
                     (config::get_global_keymap().goto_show_hn_view.to_string(), "Go to show HN view"),

--- a/hackernews_tui/src/view/help_view.rs
+++ b/hackernews_tui/src/view/help_view.rs
@@ -64,7 +64,10 @@ impl HelpView {
         LinearLayout::vertical()
             .with(|s| {
                 self.key_groups.iter().for_each(|(group_desc, keys)| {
-                    s.add_child(TextView::new(group_desc.to_string()));
+                    s.add_child(TextView::new(StyledString::styled(
+                        *group_desc,
+                        config::get_config_theme().component_style.title,
+                    )));
                     s.add_child(HelpView::construct_keys_view(keys));
                 });
             })

--- a/hackernews_tui/src/view/story_view.rs
+++ b/hackernews_tui/src/view/story_view.rs
@@ -226,32 +226,32 @@ pub fn get_story_main_view(
 
 fn get_story_view_title_bar(tag: &'static str) -> impl View {
     let style = config::get_config_theme().component_style.title_bar.into();
-    let app_name = StyledString::styled(
-        " Hacker News TUI",
+    let mut title = StyledString::styled(
+        "[Y]",
+        Style::from(style)
+            .combine(Style::from(config::get_config_theme().palette.light_white))
+            .combine(Style::from(Effect::Bold)),
+    );
+    title.append_styled(
+        " Hacker News",
         Style::from(style).combine(Style::from(Effect::Bold)),
     );
 
-    let mut tags = StyledString::new();
     for (i, item) in STORY_TAGS.iter().enumerate() {
-        tags.append_styled(" | ", style);
+        title.append_styled(" | ", style);
         if *item == tag {
-            tags.append_styled(
+            title.append_styled(
                 format!("{}.{}", i + 1, item),
                 Style::from(style)
                     .combine(Style::from(config::get_config_theme().palette.light_white)),
             );
         } else {
-            tags.append_styled(format!("{}.{}", i + 1, item), style);
+            title.append_styled(format!("{}.{}", i + 1, item), style);
         }
     }
-    tags.append_styled(" | ", style);
+    title.append_styled(" | ", style);
 
-    Layer::with_color(
-        LinearLayout::horizontal()
-            .child(TextView::new(app_name))
-            .child(TextView::new(tags)),
-        style,
-    )
+    PaddedView::lrtb(0, 0, 0, 1, Layer::with_color(TextView::new(title), style))
 }
 
 /// Return a StoryView given a story list and the view description


### PR DESCRIPTION
## Brief description of changes

### `StoryView`
- re-design the `StoryView` to make it look like HN webpage
- add a title bar for `StoryView` inspired by HN title bar

New `StoryView`:
<img width="1249" alt="Screen Shot 2021-12-16 at 2 53 31 PM" src="https://user-images.githubusercontent.com/40011582/146440085-284ba4eb-a5ce-4d6c-8a68-01a14b4fcf26.png">

### `CommentView`
- add top padding with '▔' for top comments
- add left padding with '▎' for child comments

New `CommentView`:
<img width="1419" alt="Screen Shot 2021-12-16 at 2 57 05 PM" src="https://user-images.githubusercontent.com/40011582/146440574-439e39e8-6f40-4a57-8e50-5a97c2c04a5f.png">

### Loading screen
- implement custom loading screens, including
  + pacman loading screen (default - use `use_pacman_loading` config option to configure)
  + `async_loading_view`-based loading screen with custom colors

New loading screen (pacman):
![Screen Recording 2021-12-16 at 2 58 39 PM](https://user-images.githubusercontent.com/40011582/146441059-d1acb707-792e-4d24-8e74-50c5da35ee69.gif)


### General
- tweak application default color palette
- add more component styles
- change `config::ColorStyle` to `config::Style` and allow to specify at most one `Effect` per `Style`
- add top,left padding (a padding character with color) support for `view::text_view::TextView`

### Breaking changes
- change the default shortcuts for switching story views by tags from:
    - `front_page`: `C-f` to `F1`
    - `story`: `C-z` to `F2`
    - `ask_hn`: `C-x` to `F3`
    - `show_hn`: `C-c` to `F4`
    - `ask_hn`: `C-v` to `F5`