### PR TITLE
[#51] add font highlight for `CommentView` and `StoryView`

### DIFF
--- a/hackernews_tui/src/client/parser.rs
+++ b/hackernews_tui/src/client/parser.rs
@@ -17,7 +17,7 @@ lazy_static! {
         r"<p>(?s)(?P<quote>>[> ]*)(?P<text>.*?)</p>",
         // a regex that matches an HTML italic string
         r"<i>(?s)(?P<italic>.*?)</i>",
-        // a regex that matches a HTML code block
+        // a regex that matches a HTML code block (multiline)
         r"<pre><code>(?s)(?P<code>.*?)[\n]*</code></pre>",
         // a regex that matches a HTML link
         r#"<a\s+?href="(?P<link>.*?)"(?s).+?</a>"#,
@@ -320,6 +320,7 @@ fn parse(text: String, style: Style, begin_link_id: usize) -> (StyledString, Vec
                         utils::shorten_url(m.as_str()),
                         style.combine(config::get_config_theme().component_style.link),
                     ),
+                    StyledString::plain(" "),
                     StyledString::styled(
                         format!("[{}]", links.len() + begin_link_id),
                         style.combine(config::get_config_theme().component_style.link_id),

--- a/hackernews_tui/src/client/parser.rs
+++ b/hackernews_tui/src/client/parser.rs
@@ -10,7 +10,7 @@ lazy_static! {
     /// a regex used to parse a HN comment (in HTML format)
     /// It consists of multiple regex(s) representing different elements
     static ref COMMENT_RE: Regex = Regex::new(&format!(
-        "(({})|({})|({})|({})|({}))",
+        "(({})|({})|({})|({})|({})|({}))",
         // a regex that matches a HTML paragraph
         r"<p>(?s)(?P<paragraph>(|[^>].*?))</p>",
         // a regex that matches a paragraph quote (in markdown format)
@@ -18,7 +18,9 @@ lazy_static! {
         // a regex that matches an HTML italic string
         r"<i>(?s)(?P<italic>.*?)</i>",
         // a regex that matches a HTML code block (multiline)
-        r"<pre><code>(?s)(?P<code>.*?)[\n]*</code></pre>",
+        r"<pre><code>(?s)(?P<multiline_code>.*?)[\n]*</code></pre>",
+        // a regex that matches a single line code block (markdown format)
+        "`(?P<code>[^`]+?)`",
         // a regex that matches a HTML link
         r#"<a\s+?href="(?P<link>.*?)"(?s).+?</a>"#,
     )).unwrap();
@@ -326,7 +328,7 @@ fn parse(text: String, style: Style, begin_link_id: usize) -> (StyledString, Vec
                         style.combine(config::get_config_theme().component_style.link_id),
                     ),
                 ])
-            } else if let Some(m) = caps.name("code") {
+            } else if let Some(m) = caps.name("multiline_code") {
                 StyledString::styled(
                     m.as_str(),
                     style.combine(
@@ -334,6 +336,11 @@ fn parse(text: String, style: Style, begin_link_id: usize) -> (StyledString, Vec
                             .component_style
                             .multiline_code_block,
                     ),
+                )
+            } else if let Some(m) = caps.name("code") {
+                StyledString::styled(
+                    m.as_str(),
+                    style.combine(config::get_config_theme().component_style.single_code_block),
                 )
             } else if let Some(m) = caps.name("italic") {
                 StyledString::styled(

--- a/hackernews_tui/src/client/parser.rs
+++ b/hackernews_tui/src/client/parser.rs
@@ -12,15 +12,15 @@ lazy_static! {
     static ref COMMENT_RE: Regex = Regex::new(&format!(
         "(({})|({})|({})|({})|({}))",
         // a regex that matches a HTML paragraph
-        r"<p>(?s)(?P<paragraph>[^>].*?)</p>",
+        r"<p>(?s)(?P<paragraph>(|[^>].*?))</p>",
         // a regex that matches a paragraph quote (in markdown format)
         r"<p>(?s)(?P<quote>>[> ]*)(?P<text>.*?)</p>",
         // a regex that matches an HTML italic string
-        r"<i>(?s)(?P<italic>.+?)</i>",
+        r"<i>(?s)(?P<italic>.*?)</i>",
         // a regex that matches a HTML code block
-        r"<pre><code>(?s)(?P<code>.+?)[\n]*</code></pre>",
+        r"<pre><code>(?s)(?P<code>.*?)[\n]*</code></pre>",
         // a regex that matches a HTML link
-        r#"<a\s+?href="(?P<link>.+?)"(?s).+?</a>"#,
+        r#"<a\s+?href="(?P<link>.*?)"(?s).+?</a>"#,
     )).unwrap();
 }
 
@@ -265,6 +265,8 @@ fn parse_raw_html_comment(text: &str, metadata: StyledString) -> (StyledString, 
 
 /// a helper function for parsing comment text that allows recursively parsing sub elements of the text.
 fn parse(text: String, style: Style, begin_link_id: usize) -> (StyledString, Vec<String>) {
+    debug!("parse {}", text);
+
     let mut curr_pos = 0;
     let mut s = StyledString::new();
     let mut links = vec![];

--- a/hackernews_tui/src/client/parser.rs
+++ b/hackernews_tui/src/client/parser.rs
@@ -167,7 +167,7 @@ impl From<StoryResponse> for Story {
         let mut parsed_title = StyledString::new();
 
         let title = {
-            // parse title based on the post's category
+            // parse story title based on the post's category
             if let Some(title) = title.strip_prefix("Ask HN") {
                 parsed_title
                     .append_styled("Ask HN", config::get_config_theme().component_style.ask_hn);
@@ -195,10 +195,8 @@ impl From<StoryResponse> for Story {
             }
         };
 
-        // parse a HTML story title that may contain search matches wrapped
-        // inside <em> tags into a styled string
+        // parse story title that may contain search matches wrapped inside `<em>` tags
         let mut curr_pos = 0;
-
         for caps in MATCH_RE.captures_iter(title) {
             let whole_match = caps.get(0).unwrap();
             // the part that doesn't match any patterns should be rendered in the default style
@@ -212,7 +210,6 @@ impl From<StoryResponse> for Story {
                 config::get_config_theme().component_style.matched_highlight,
             );
         }
-
         if curr_pos < title.len() {
             parsed_title.append_plain(&title[curr_pos..title.len()]);
         }
@@ -314,7 +311,6 @@ fn parse(text: String, style: Style, begin_link_id: usize) -> (StyledString, Vec
                 }
 
                 // render quote character `>` as indentation character
-                info!("{}", m_quote.as_str());
                 let quote_s = StyledString::styled(
                     "▎"
                         .to_string()

--- a/hackernews_tui/src/config/theme.rs
+++ b/hackernews_tui/src/config/theme.rs
@@ -60,6 +60,10 @@ pub struct ComponentStyle {
     pub current_story_tag: Style,
     pub username: Style,
     pub loading_bar: Style,
+    pub ask_hn: Style,
+    pub tell_hn: Style,
+    pub show_hn: Style,
+    pub launch_hn: Style,
 }
 
 impl Default for Palette {
@@ -121,6 +125,18 @@ impl Default for ComponentStyle {
             loading_bar: Style::default()
                 .front(Color::parse("light yellow"))
                 .back(Color::parse("blue")),
+            ask_hn: Style::default()
+                .front(Color::parse("red"))
+                .effect(Effect::Bold),
+            tell_hn: Style::default()
+                .front(Color::parse("yellow"))
+                .effect(Effect::Bold),
+            show_hn: Style::default()
+                .front(Color::parse("blue"))
+                .effect(Effect::Bold),
+            launch_hn: Style::default()
+                .front(Color::parse("green"))
+                .effect(Effect::Bold),
         }
     }
 }

--- a/hackernews_tui/src/config/theme.rs
+++ b/hackernews_tui/src/config/theme.rs
@@ -55,6 +55,7 @@ pub struct ComponentStyle {
     pub single_code_block: Style,
     pub multiline_code_block: Style,
     pub quote: Style,
+    pub italic: Style,
     pub metadata: Style,
     pub current_story_tag: Style,
     pub username: Style,
@@ -114,6 +115,7 @@ impl Default for ComponentStyle {
             quote: Style::default()
                 .front(Color::parse("white"))
                 .effect(Effect::Bold),
+            italic: Style::default().effect(Effect::Italic),
             metadata: Style::default().front(Color::parse("#828282")),
             username: Style::default().effect(Effect::Bold),
             loading_bar: Style::default()

--- a/hackernews_tui/src/config/theme.rs
+++ b/hackernews_tui/src/config/theme.rs
@@ -52,7 +52,9 @@ pub struct ComponentStyle {
     pub link: Style,
     pub link_id: Style,
     pub matched_highlight: Style,
-    pub code_block: Style,
+    pub single_code_block: Style,
+    pub multiline_code_block: Style,
+    pub quote: Style,
     pub metadata: Style,
     pub current_story_tag: Style,
     pub username: Style,
@@ -103,9 +105,15 @@ impl Default for ComponentStyle {
             matched_highlight: Style::default()
                 .front(Color::parse("black"))
                 .back(Color::parse("#ffff55")),
-            code_block: Style::default()
+            single_code_block: Style::default()
                 .front(Color::parse("black"))
                 .back(Color::parse("#c8c8c8")),
+            multiline_code_block: Style::default()
+                .front(Color::parse("light black"))
+                .effect(Effect::Bold),
+            quote: Style::default()
+                .front(Color::parse("white"))
+                .effect(Effect::Bold),
             metadata: Style::default().front(Color::parse("#828282")),
             username: Style::default().effect(Effect::Bold),
             loading_bar: Style::default()

--- a/hackernews_tui/src/main.rs
+++ b/hackernews_tui/src/main.rs
@@ -2,6 +2,7 @@
 pub mod client;
 pub mod config;
 pub mod prelude;
+pub mod regex;
 pub mod utils;
 pub mod view;
 

--- a/hackernews_tui/src/main.rs
+++ b/hackernews_tui/src/main.rs
@@ -2,7 +2,6 @@
 pub mod client;
 pub mod config;
 pub mod prelude;
-pub mod regex;
 pub mod utils;
 pub mod view;
 

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -283,8 +283,8 @@ fn get_comment_main_view(receiver: client::CommentReceiver) -> impl View {
                 Ok(num) => {
                     s.raw_command.clear();
                     let id = s.get_focus_index();
-                    if num < s.comments[id].links.len() {
-                        utils::open_url_in_browser(&s.comments[id].links[num]);
+                    if num > 0 && num <= s.comments[id].links.len() {
+                        utils::open_url_in_browser(&s.comments[id].links[num - 1]);
                         Some(EventResult::Consumed(None))
                     } else {
                         Some(EventResult::Consumed(None))
@@ -299,8 +299,8 @@ fn get_comment_main_view(receiver: client::CommentReceiver) -> impl View {
                 Ok(num) => {
                     s.raw_command.clear();
                     let id = s.get_focus_index();
-                    if num < s.comments[id].links.len() {
-                        let url = s.comments[id].links[num].clone();
+                    if num > 0 && num <= s.comments[id].links.len() {
+                        let url = s.comments[id].links[num - 1].clone();
                         Some(EventResult::with_cb({
                             move |s| article_view::add_article_view_layer(s, &url)
                         }))

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -327,7 +327,8 @@ fn get_comment_main_view(receiver: client::CommentReceiver) -> impl View {
 
 /// Return a CommentView given a comment list and the discussed story's url/title
 pub fn get_comment_view(story: &client::Story, receiver: client::CommentReceiver) -> impl View {
-    let status_bar = utils::construct_view_title_bar(&format!("Comment View - {}", story.title));
+    let status_bar =
+        utils::construct_view_title_bar(&format!("Comment View - {}", story.title.source()));
 
     let main_view = get_comment_main_view(receiver);
 

--- a/hackernews_tui/src/view/help_view.rs
+++ b/hackernews_tui/src/view/help_view.rs
@@ -21,8 +21,10 @@ impl HelpView {
     }
 
     fn construct_key_view(key: String, desc: String, max_key_width: usize) -> impl View {
-        let key_string =
-            StyledString::styled(key, config::get_config_theme().component_style.code_block);
+        let key_string = StyledString::styled(
+            key,
+            config::get_config_theme().component_style.single_code_block,
+        );
         let desc_string = StyledString::plain(desc);
         LinearLayout::horizontal()
             .child(TextView::new(key_string).fixed_width(max_key_width))

--- a/hackernews_tui/src/view/story_view.rs
+++ b/hackernews_tui/src/view/story_view.rs
@@ -5,7 +5,6 @@ use super::help_view::HasHelpView;
 use super::list_view::*;
 use super::text_view;
 use crate::prelude::*;
-use regex::Regex;
 
 static STORY_TAGS: [&str; 5] = ["front_page", "story", "ask_hn", "show_hn", "job"];
 
@@ -53,49 +52,9 @@ impl StoryView {
         }
     }
 
-    /// Return a StyledString representing a matched text in which
-    /// matches are highlighted
-    fn get_matched_text(mut s: String) -> StyledString {
-        let match_re = Regex::new(r"<em>(?P<match>.*?)</em>").unwrap();
-        let mut styled_s = StyledString::new();
-
-        loop {
-            match match_re.captures(&s.clone()) {
-                None => break,
-                Some(c) => {
-                    let m = c.get(0).unwrap();
-                    let matched_text = c.name("match").unwrap().as_str();
-
-                    let range = m.range();
-                    let mut prefix: String = s
-                        .drain(std::ops::Range {
-                            start: 0,
-                            end: m.end(),
-                        })
-                        .collect();
-                    prefix.drain(range);
-
-                    if !prefix.is_empty() {
-                        styled_s.append_plain(&prefix);
-                    }
-
-                    styled_s.append_styled(
-                        matched_text,
-                        config::get_config_theme().component_style.matched_highlight,
-                    );
-                    continue;
-                }
-            };
-        }
-        if !s.is_empty() {
-            styled_s.append_plain(s);
-        }
-        styled_s
-    }
-
     /// Get the description text summarizing basic information about a story
     fn get_story_text(max_id_width: usize, story: &client::Story) -> StyledString {
-        let mut story_text = Self::get_matched_text(story.highlight_result.title.clone());
+        let mut story_text = story.title.clone();
 
         if let Ok(url) = url::Url::parse(&story.url) {
             if let Some(domain) = url.domain() {


### PR DESCRIPTION
Part 1 of #51.

## Brief description of changes
- rewrite the parser function for parsing HN comment (as HTML text)
- add font highlighting for `CommentView` that adds highlight/color to
   + italic
   + quote paragraph
   + single code block surrounded by ``
   + multi-line code block
- add font highlighting for `StoryView` that adds highlight/color to story's categories (`Show HN`, `Ask HN`, etc) and implement a parser for parsing story title
- make link ID in comment text starts from `1` and change the corresponding `open_link_*` commands in `CommentView`
- add more component styles