### PR TITLE
Add story tag navigation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ In each `View`, press `?` to see a list of supported keyboard shortcuts and thei
 - `s`: Open in browser the focused story
 - `n`: Go to the next page
 - `p`: Go the previous page
-- `d`: Toggle sort by date/popularity
+- `d`: Toggle sort by date
 
 #### Article View shortcuts
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ In each `View`, press `?` to see a list of supported keyboard shortcuts and thei
 - `k`: Focus the previous story
 - `{story_id} g`: Focus the {story_id}-th story
 - `enter`: Go the comment view associated with the focused story
+- `l`: Go to the next story tag
+- `h`: Go to the previous story tag
 - `o`: Open in browser the article associated with the focused story
 - `O`: Open in article view the article associated with the focused story
 - `s`: Open in browser the focused story

--- a/examples/hn-tui.toml
+++ b/examples/hn-tui.toml
@@ -88,6 +88,8 @@
 # open_article_in_article_view = "O"
 # open_story_in_browser = "s"
 # goto_story_comment_view = "enter"
+# next_story_tag = "l"
+# prev_story_tag = "h"
 
 #[keymap.search_view_keymap]
 # to_navigation_mode = "esc"
@@ -144,7 +146,7 @@
 # [[keymap.custom_keymap.custom_view_navigation]]
 # key = "M-1"
 # tag = "story"
-# by_date = false # true to sort_by date, false to sort_by popularity
+# by_date = false
 # [keymap.custom_keymap.custom_view_navigation.numeric_filters]
 # elapsed_days_interval = {start = 0, end = 3} # stories posted between now and 3 days ago
 # points_interval = {start = 10} # stories with points >= 10

--- a/hackernews_tui/src/config/keybindings.rs
+++ b/hackernews_tui/src/config/keybindings.rs
@@ -86,6 +86,10 @@ impl Default for GlobalKeyMap {
 
 #[derive(Debug, Clone, Deserialize, ConfigParse)]
 pub struct StoryViewKeyMap {
+    // story tags navigation keymaps
+    pub next_story_tag: Key,
+    pub prev_story_tag: Key,
+
     // stories navigation keymaps
     pub next_story: Key,
     pub prev_story: Key,
@@ -107,6 +111,8 @@ pub struct StoryViewKeyMap {
 impl Default for StoryViewKeyMap {
     fn default() -> Self {
         StoryViewKeyMap {
+            next_story_tag: Key::new('l'),
+            prev_story_tag: Key::new('h'),
             next_story: Key::new('j'),
             prev_story: Key::new('k'),
             goto_story: Key::new('g'),

--- a/hackernews_tui/src/main.rs
+++ b/hackernews_tui/src/main.rs
@@ -16,7 +16,7 @@ macro_rules! set_up_switch_view_shortcut {
                 s,
                 $client,
                 $tag,
-                false,
+                true,
                 0,
                 client::StoryNumericFilters::default(),
                 false,

--- a/hackernews_tui/src/view/help_view.rs
+++ b/hackernews_tui/src/view/help_view.rs
@@ -245,10 +245,20 @@ impl HasHelpView for story_view::StoryView {
             help_view = help_view.key_groups(vec![("Custom keymaps", custom_keymaps)]);
         }
         help_view.key_groups(vec![
-            view_navigation_key_shortcuts!((
-                story_view_keymap.goto_story_comment_view.to_string(),
-                "Go to the comment view associated with the focused story"
-            )),
+            view_navigation_key_shortcuts!(
+                (
+                    story_view_keymap.goto_story_comment_view.to_string(),
+                    "Go to the comment view associated with the focused story"
+                ),
+                (
+                    story_view_keymap.next_story_tag.to_string(),
+                    "Go to the next story tag"
+                ),
+                (
+                    story_view_keymap.prev_story_tag.to_string(),
+                    "Go to the previous story tag"
+                )
+            ),
             other_key_shortcuts!(),
         ])
     }

--- a/hackernews_tui/src/view/help_view.rs
+++ b/hackernews_tui/src/view/help_view.rs
@@ -172,7 +172,7 @@ impl HasHelpView for story_view::StoryView {
                 (
                     keymap.key.to_string(),
                     format!(
-                        "Go to {} view (sort_by: {}, {})",
+                        "Go to {} view (by_date: {}, {})",
                         match keymap.tag.as_str() {
                             "front_page" => "front page",
                             "story" => "all stories",
@@ -181,7 +181,7 @@ impl HasHelpView for story_view::StoryView {
                             "show_hn" => "show HN",
                             _ => panic!("unknown view: {}", keymap.tag),
                         },
-                        if keymap.by_date { "date" } else { "popularity" },
+                        keymap.by_date,
                         keymap.numeric_filters.desc()
                     ),
                 )
@@ -219,7 +219,7 @@ impl HasHelpView for story_view::StoryView {
                     ),
                     (
                         story_view_keymap.toggle_sort_by.to_string(),
-                        "Toggle sort by date/popularity (only for non `Front Page` views)",
+                        "Toggle sort by date (only for non `Front Page` views)",
                     ),
                 ],
             ),
@@ -408,7 +408,7 @@ impl HasHelpView for search_view::SearchView {
                     ),
                     (
                         story_view_keymap.toggle_sort_by.to_string(),
-                        "Toggle sort by date/popularity",
+                        "Toggle sort by date",
                     ),
                 ],
             ),

--- a/hackernews_tui/src/view/story_view.rs
+++ b/hackernews_tui/src/view/story_view.rs
@@ -4,6 +4,7 @@ use super::comment_view;
 use super::help_view::HasHelpView;
 use super::list_view::*;
 use super::text_view;
+use crate::client::StoryNumericFilters;
 use crate::prelude::*;
 
 static STORY_TAGS: [&str; 5] = ["front_page", "story", "ask_hn", "show_hn", "job"];
@@ -254,7 +255,7 @@ pub fn get_story_view(
             if tag == "front_page" {
                 return;
             }
-            add_story_view_layer(s, client, tag, !by_date, page, numeric_filters, true);
+            add_story_view_layer(s, client, tag, !by_date, 0, numeric_filters, true);
         })
         // story tag navigation
         .on_event(story_view_keymap.next_story_tag, move |s| {
@@ -262,10 +263,10 @@ pub fn get_story_view(
                 s,
                 client,
                 STORY_TAGS[(current_tag_pos + 1) % STORY_TAGS.len()],
-                by_date,
-                page,
-                numeric_filters,
                 true,
+                0,
+                StoryNumericFilters::default(),
+                false,
             );
         })
         .on_event(story_view_keymap.prev_story_tag, move |s| {
@@ -273,10 +274,10 @@ pub fn get_story_view(
                 s,
                 client,
                 STORY_TAGS[(current_tag_pos + STORY_TAGS.len() - 1) % STORY_TAGS.len()],
-                by_date,
-                page,
-                numeric_filters,
                 true,
+                0,
+                StoryNumericFilters::default(),
+                false,
             );
         })
         // paging

--- a/hackernews_tui/src/view/story_view.rs
+++ b/hackernews_tui/src/view/story_view.rs
@@ -237,6 +237,11 @@ pub fn get_story_view(
         .child(utils::construct_footer_view::<StoryView>());
     view.set_focus_index(1).unwrap_or_else(|_| {});
 
+    let current_tag_pos = STORY_TAGS
+        .iter()
+        .position(|t| *t == tag)
+        .unwrap_or_else(|| panic!("unkwnown tag {}", tag));
+
     let story_view_keymap = config::get_story_view_keymap().clone();
 
     OnEventView::new(view)
@@ -250,6 +255,29 @@ pub fn get_story_view(
                 return;
             }
             add_story_view_layer(s, client, tag, !by_date, page, numeric_filters, true);
+        })
+        // story tag navigation
+        .on_event(story_view_keymap.next_story_tag, move |s| {
+            add_story_view_layer(
+                s,
+                client,
+                STORY_TAGS[(current_tag_pos + 1) % STORY_TAGS.len()],
+                by_date,
+                page,
+                numeric_filters,
+                true,
+            );
+        })
+        .on_event(story_view_keymap.prev_story_tag, move |s| {
+            add_story_view_layer(
+                s,
+                client,
+                STORY_TAGS[(current_tag_pos + STORY_TAGS.len() - 1) % STORY_TAGS.len()],
+                by_date,
+                page,
+                numeric_filters,
+                true,
+            );
         })
         // paging
         .on_event(story_view_keymap.prev_page, move |s| {


### PR DESCRIPTION
## Brief description of changes

- add `next_story_tag` and `prev_story_tag` commands in `StoryView` for moving between consecutive story tags
- add default shortcuts for the above commands: `next_story_tag: l`, `prev_story_tag: h`
- change default `by_date` value for `show_hn`, `ask_hn` `story` tag from `false` to `true`