### PR TITLE
Render story text in comment view

### DIFF
--- a/NOTES.org
+++ b/NOTES.org
@@ -3,7 +3,7 @@
 
 * Roadmap
 
-** ONGOING Render story/comment main text in ~CommentView~
+** DONE Render story/comment main text in ~CommentView~
 
 ** TODO Improve error message for config parser
 
@@ -25,5 +25,13 @@ More specifically, open link starting with ~https://news.ycombinator.com/item?id
 
 
 * Changes
-** [[https://github.com/aome510/hackernews-TUI/pull/62][Render story text in comment view #62]]
+** [[https://github.com/aome510/hackernews-TUI/pull/62][Render story text in comment view #62]] :ATTACH:
+:PROPERTIES:
+:ID:       024b344d-e592-45d0-8957-0477a4f95139
+:END:
 This PR implements [[*Render story/comment main text in ~CommentView~]].
+
+- Render a story text on the top of the ~CommentView~:
+
+  #+attr_html: :width 1000
+  [[attachment:_20220109_200339Screen Shot 2022-01-09 at 8.03.36 PM.png]]

--- a/hackernews_tui/src/client/mod.rs
+++ b/hackernews_tui/src/client/mod.rs
@@ -3,7 +3,7 @@ mod parser;
 mod query;
 
 // re-export
-pub use parser::{Article, Comment, CommentState, Story};
+pub use parser::{Article, CollapseState, HnText, Story};
 pub use query::StoryNumericFilters;
 
 use crate::prelude::*;
@@ -20,8 +20,8 @@ pub const SEARCH_LIMIT: usize = 15;
 
 static CLIENT: once_cell::sync::OnceCell<HNClient> = once_cell::sync::OnceCell::new();
 
-pub type CommentSender = crossbeam_channel::Sender<Vec<Comment>>;
-pub type CommentReceiver = crossbeam_channel::Receiver<Vec<Comment>>;
+pub type CommentSender = crossbeam_channel::Sender<Vec<HnText>>;
+pub type CommentReceiver = crossbeam_channel::Receiver<Vec<HnText>>;
 
 /// HNClient is a HTTP client to communicate with Hacker News APIs.
 #[derive(Clone)]

--- a/hackernews_tui/src/client/parser.rs
+++ b/hackernews_tui/src/client/parser.rs
@@ -138,10 +138,10 @@ pub struct Story {
 
 /// Comment represents a parsed Hacker News comment
 #[derive(Debug, Clone)]
-pub struct Comment {
+pub struct HnText {
     pub id: u32,
-    pub height: usize,
-    pub state: CommentState,
+    pub level: usize,
+    pub state: CollapseState,
     pub text: StyledString,
     pub minimized_text: StyledString,
     pub links: Vec<String>,
@@ -149,7 +149,7 @@ pub struct Comment {
 
 #[derive(Debug, Clone)]
 /// CommentState represents the state of a single comment component
-pub enum CommentState {
+pub enum CollapseState {
     Collapsed,
     PartiallyCollapsed,
     Normal,
@@ -264,15 +264,15 @@ impl From<StoryResponse> for Story {
     }
 }
 
-impl From<CommentResponse> for Vec<Comment> {
+impl From<CommentResponse> for Vec<HnText> {
     fn from(c: CommentResponse) -> Self {
         let mut children = c
             .children
             .into_par_iter()
             .filter(|comment| comment.author.is_some() && comment.text.is_some())
-            .flat_map(<Vec<Comment>>::from)
+            .flat_map(<Vec<HnText>>::from)
             .map(|mut c| {
-                c.height += 1; // update the height of every children comments
+                c.level += 1; // update the height of every children comments
                 c
             })
             .collect::<Vec<_>>();
@@ -289,10 +289,10 @@ impl From<CommentResponse> for Vec<Comment> {
         ]);
         let (text, links) = parse_comment(&c.text.unwrap_or_default(), metadata.clone());
 
-        let comment = Comment {
+        let comment = HnText {
             id: c.id,
-            height: 0,
-            state: CommentState::Normal,
+            level: 0,
+            state: CollapseState::Normal,
             text,
             minimized_text: utils::combine_styled_strings(vec![
                 metadata,

--- a/hackernews_tui/src/client/parser.rs
+++ b/hackernews_tui/src/client/parser.rs
@@ -260,9 +260,9 @@ impl From<StoryResponse> for Story {
                 ),
             ]);
 
-            // the HTML story text returned by HN Algolia API doesn't wrap a paragraph
-            // inside the `<p><\p>` tag pair.
-            // Instead, it seems to use `<p>` to indicate a paragraph break.
+            // the HTML story text returned by HN Algolia API doesn't wrap a
+            // paragraph inside a `<p><\p>` tag pair.
+            // Instead, it seems to use `<p>` to represent a paragraph break.
             let mut story_text = decode_html(&s.text.unwrap_or_default()).replace("<p>", "\n\n");
 
             let minimized_text = if story_text.is_empty() {
@@ -312,7 +312,7 @@ impl From<CommentResponse> for Vec<HnText> {
             .filter(|comment| comment.author.is_some() && comment.text.is_some())
             .flat_map(<Vec<HnText>>::from)
             .map(|mut c| {
-                c.level += 1; // update the height of every children comments
+                c.level += 1; // update the level of every children comments
                 c
             })
             .collect::<Vec<_>>();

--- a/hackernews_tui/src/client/parser.rs
+++ b/hackernews_tui/src/client/parser.rs
@@ -255,7 +255,7 @@ impl From<StoryResponse> for Story {
             let mut links = vec![];
 
             parse_hn_html_text(
-                s.text.unwrap_or_default(),
+                decode_html(&s.text.unwrap_or_default()),
                 Style::default(),
                 &mut text,
                 &mut links,
@@ -311,11 +311,12 @@ impl From<CommentResponse> for Vec<HnText> {
                 ),
             ]);
 
-            let mut text = metadata.clone();
+            let mut text =
+                utils::combine_styled_strings(vec![metadata.clone(), StyledString::plain("\n")]);
             let mut links = vec![];
 
             parse_hn_html_text(
-                c.text.unwrap_or_default(),
+                decode_html(&c.text.unwrap_or_default()),
                 Style::default(),
                 &mut text,
                 &mut links,

--- a/hackernews_tui/src/client/parser.rs
+++ b/hackernews_tui/src/client/parser.rs
@@ -76,6 +76,7 @@ pub struct StoryResponse {
 
     author: Option<String>,
     url: Option<String>,
+    #[serde(rename(deserialize = "story_text"))]
     text: Option<String>,
 
     #[serde(default)]
@@ -240,13 +241,21 @@ impl From<StoryResponse> for Story {
             parsed_title.append_plain(&title[curr_pos..title.len()]);
         }
 
+        let author = s.author.unwrap_or_else(|| String::from("[deleted]"));
+
         // parse story's text
         let text = {
             let metadata = utils::combine_styled_strings(vec![
                 StyledString::plain(parsed_title.source()),
                 StyledString::plain("\n"),
                 StyledString::styled(
-                    format!(" {} ago ", utils::get_elapsed_time_as_text(s.time)),
+                    format!(
+                        "{} points | by {} | {} ago | {} comments\n",
+                        s.points,
+                        author,
+                        utils::get_elapsed_time_as_text(s.time),
+                        s.num_comments,
+                    ),
                     config::get_config_theme().component_style.metadata,
                 ),
             ]);
@@ -274,7 +283,7 @@ impl From<StoryResponse> for Story {
         Story {
             title: parsed_title,
             url: s.url.unwrap_or_default(),
-            author: s.author.unwrap_or_else(|| String::from("[deleted]")),
+            author,
             id: s.id,
             points: s.points,
             num_comments: s.num_comments,

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -87,23 +87,23 @@ impl CommentView {
         self.layout(self.get_scroller().last_outer_size())
     }
 
-    /// Return the `id` of the first (`direction` dependent and starting but not including `start_id`)
-    /// comment which has the `height` less than or equal the `max_height`
-    pub fn find_comment_id_by_max_height(
+    /// Return the id of the first comment (`direction` dependent)
+    /// whose level is less than or equal `max_level`.
+    pub fn find_comment_id_by_max_level(
         &self,
         start_id: usize,
-        max_height: usize,
+        max_level: usize,
         direction: bool,
     ) -> usize {
         if direction {
             // ->
             (start_id + 1..self.len())
-                .find(|&id| self.comments[id].level <= max_height)
+                .find(|&id| self.comments[id].level <= max_level)
                 .unwrap_or_else(|| self.len())
         } else {
             // <-
             (0..start_id)
-                .rfind(|&id| self.comments[id].level <= max_height)
+                .rfind(|&id| self.comments[id].level <= max_level)
                 .unwrap_or(start_id)
         }
     }
@@ -165,7 +165,7 @@ impl CommentView {
                 }
 
                 // skip toggling all child comments of the current comment
-                let next_id = self.find_comment_id_by_max_height(i, self.comments[i].level, true);
+                let next_id = self.find_comment_id_by_max_level(i, self.comments[i].level, true);
                 self.toggle_comment_collapse_state(next_id, min_height)
             }
         };
@@ -262,28 +262,28 @@ fn get_comment_main_view(
         })
         .on_pre_event_inner(comment_view_keymap.next_leq_level_comment, move |s, _| {
             let id = s.get_focus_index();
-            let next_id = s.find_comment_id_by_max_height(id, s.comments[id].level, true);
+            let next_id = s.find_comment_id_by_max_level(id, s.comments[id].level, true);
             s.set_focus_index(next_id)
         })
         .on_pre_event_inner(comment_view_keymap.prev_leq_level_comment, move |s, _| {
             let id = s.get_focus_index();
-            let next_id = s.find_comment_id_by_max_height(id, s.comments[id].level, false);
+            let next_id = s.find_comment_id_by_max_level(id, s.comments[id].level, false);
             s.set_focus_index(next_id)
         })
         .on_pre_event_inner(comment_view_keymap.next_top_level_comment, move |s, _| {
             let id = s.get_focus_index();
-            let next_id = s.find_comment_id_by_max_height(id, 0, true);
+            let next_id = s.find_comment_id_by_max_level(id, 0, true);
             s.set_focus_index(next_id)
         })
         .on_pre_event_inner(comment_view_keymap.prev_top_level_comment, move |s, _| {
             let id = s.get_focus_index();
-            let next_id = s.find_comment_id_by_max_height(id, 0, false);
+            let next_id = s.find_comment_id_by_max_level(id, 0, false);
             s.set_focus_index(next_id)
         })
         .on_pre_event_inner(comment_view_keymap.parent_comment, move |s, _| {
             let id = s.get_focus_index();
             if s.comments[id].level > 0 {
-                let next_id = s.find_comment_id_by_max_height(id, s.comments[id].level - 1, false);
+                let next_id = s.find_comment_id_by_max_level(id, s.comments[id].level - 1, false);
                 s.set_focus_index(next_id)
             } else {
                 Some(EventResult::Consumed(None))


### PR DESCRIPTION
## Brief description of changes

- implement story text rendering
- use `level` to indicate comment's depth instead of `height`
- rename `Comment` to `HnText`, `COMMENT_RE` to `HN_TEXT_RE`, `CommentState` to `CollapseState`. Use `HnText` to represent a HN text (comment/story)