### PR TITLE
Code refactor and clean part II

### DIFF
--- a/hackernews_tui/src/client/mod.rs
+++ b/hackernews_tui/src/client/mod.rs
@@ -255,7 +255,6 @@ impl HNClient {
         page: usize,
         numeric_filters: query::StoryNumericFilters,
     ) -> Result<Vec<Story>> {
-        return Err(anyhow::anyhow!("error..."));
         if tag == "front_page" {
             return self.get_front_page_stories(page, numeric_filters);
         }

--- a/hackernews_tui/src/client/mod.rs
+++ b/hackernews_tui/src/client/mod.rs
@@ -29,7 +29,7 @@ pub struct HNClient {
     client: ureq::Agent,
 }
 
-/// A macro to log the runtime of an epxression
+/// A macro to log the runtime of an expression
 macro_rules! log {
     ($e:expr, $desc:expr) => {{
         let time = std::time::SystemTime::now();

--- a/hackernews_tui/src/client/mod.rs
+++ b/hackernews_tui/src/client/mod.rs
@@ -29,6 +29,7 @@ pub struct HNClient {
     client: ureq::Agent,
 }
 
+/// A macro to log the runtime of an epxression
 macro_rules! log {
     ($e:expr, $desc:expr) => {{
         let time = std::time::SystemTime::now();
@@ -81,8 +82,6 @@ impl HNClient {
 
         // loads first 5 comments to ensure the corresponding `CommentView` has data to render
         self.load_comments(&sender, &mut ids, 5)?;
-        // used to test loading bar
-        // std::thread::sleep(std::time::Duration::from_secs(1000));
         std::thread::spawn({
             let client = self.clone();
             let sleep_dur = std::time::Duration::from_millis(1000);
@@ -256,6 +255,7 @@ impl HNClient {
         page: usize,
         numeric_filters: query::StoryNumericFilters,
     ) -> Result<Vec<Story>> {
+        return Err(anyhow::anyhow!("error..."));
         if tag == "front_page" {
             return self.get_front_page_stories(page, numeric_filters);
         }

--- a/hackernews_tui/src/client/parser.rs
+++ b/hackernews_tui/src/client/parser.rs
@@ -147,12 +147,13 @@ pub struct HnText {
     pub level: usize,
     pub state: CollapseState,
     pub text: StyledString,
+    /// The minimized version of the text used to display the text component when it's collapsed.
     pub minimized_text: StyledString,
     pub links: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
-/// The collapse state of a text component
+/// The collapse state of a HN text component
 pub enum CollapseState {
     Collapsed,
     PartiallyCollapsed,

--- a/hackernews_tui/src/client/parser.rs
+++ b/hackernews_tui/src/client/parser.rs
@@ -147,7 +147,7 @@ pub struct HnText {
     pub level: usize,
     pub state: CollapseState,
     pub text: StyledString,
-    /// The minimized version of the text used to display the text component when it's collapsed.
+    /// The minimized version of the text used to display the text component when it's partially collapsed.
     pub minimized_text: StyledString,
     pub links: Vec<String>,
 }

--- a/hackernews_tui/src/client/query.rs
+++ b/hackernews_tui/src/client/query.rs
@@ -7,15 +7,15 @@ pub struct FilterInterval<T> {
     end: Option<T>,
 }
 
-impl<T: std::fmt::Display + Copy> FilterInterval<T> {
+impl<T: std::fmt::Display> FilterInterval<T> {
     pub fn query(&self, field: &str) -> String {
         format!(
             "{}{}",
-            match self.start {
+            match self.start.as_ref() {
                 Some(x) => format!(",{}>={}", field, x),
                 None => "".to_string(),
             },
-            match self.end {
+            match self.end.as_ref() {
                 Some(x) => format!(",{}<{}", field, x),
                 None => "".to_string(),
             },
@@ -26,11 +26,11 @@ impl<T: std::fmt::Display + Copy> FilterInterval<T> {
         format!(
             "{}: [{}:{}]",
             field,
-            match self.start {
+            match self.start.as_ref() {
                 Some(x) => x.to_string(),
                 None => "".to_string(),
             },
-            match self.end {
+            match self.end.as_ref() {
                 Some(x) => x.to_string(),
                 None => "".to_string(),
             }
@@ -91,5 +91,11 @@ impl StoryNumericFilters {
         } else {
             "".to_string()
         }
+    }
+}
+
+impl std::fmt::Display for StoryNumericFilters {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.desc())
     }
 }

--- a/hackernews_tui/src/config/mod.rs
+++ b/hackernews_tui/src/config/mod.rs
@@ -80,10 +80,8 @@ pub fn load_config(config_file_str: &str) {
     let config = match Config::from_config_file(&config_file) {
         Err(err) => {
             tracing::error!(
-                "failed to load configurations from the file {}: {} \
-                     \n...Use the default configurations instead",
-                config_file_str,
-                err
+                "failed to load configurations from the file {config_file_str}: {err:#}\
+                 \nUse the default configurations instead",
             );
             Config::default()
         }

--- a/hackernews_tui/src/main.rs
+++ b/hackernews_tui/src/main.rs
@@ -128,7 +128,7 @@ fn run() {
 /// initialize application logging
 fn init_logging(log_dir_str: &str) {
     if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "info")
+        std::env::set_var("RUST_LOG", "hackernews_tui=info")
     }
 
     let log_dir = std::path::PathBuf::from(log_dir_str);

--- a/hackernews_tui/src/main.rs
+++ b/hackernews_tui/src/main.rs
@@ -10,112 +10,16 @@ const DEFAULT_LOG_FILE: &str = "hn-tui.log";
 
 use clap::*;
 use prelude::*;
-use view::help_view::HasHelpView;
-
-macro_rules! set_up_switch_view_shortcut {
-    ($key:expr,$tag:expr,$s:expr,$client:expr) => {
-        $s.set_on_post_event($key, move |s| {
-            view::story_view::add_story_view_layer(
-                s,
-                $client,
-                $tag,
-                true,
-                0,
-                client::StoryNumericFilters::default(),
-                false,
-            );
-        });
-    };
-}
-
-fn set_up_global_callbacks(s: &mut Cursive, client: &'static client::HNClient) {
-    s.clear_global_callbacks(Event::CtrlChar('c'));
-
-    let global_keymap = config::get_global_keymap().clone();
-
-    // .............................................................
-    // global shortcuts for switching between different Story Views
-    // .............................................................
-
-    set_up_switch_view_shortcut!(global_keymap.goto_front_page_view, "front_page", s, client);
-    set_up_switch_view_shortcut!(global_keymap.goto_all_stories_view, "story", s, client);
-    set_up_switch_view_shortcut!(global_keymap.goto_ask_hn_view, "ask_hn", s, client);
-    set_up_switch_view_shortcut!(global_keymap.goto_show_hn_view, "show_hn", s, client);
-    set_up_switch_view_shortcut!(global_keymap.goto_jobs_view, "job", s, client);
-
-    // custom navigation shortcuts
-    config::get_config()
-        .keymap
-        .custom_keymaps
-        .iter()
-        .for_each(|data| {
-            s.set_on_post_event(data.key.clone(), move |s| {
-                view::story_view::add_story_view_layer(
-                    s,
-                    client,
-                    &data.tag,
-                    data.by_date,
-                    0,
-                    data.numeric_filters,
-                    false,
-                );
-            });
-        });
-
-    // ............................................
-    // end of navigation shortcuts for Story Views
-    // ............................................
-
-    s.set_on_post_event(global_keymap.goto_previous_view, |s| {
-        if s.screen_mut().len() > 1 {
-            s.pop_layer();
-        }
-    });
-
-    s.set_on_post_event(global_keymap.goto_search_view, move |s| {
-        view::search_view::add_search_view_layer(s, client);
-    });
-
-    s.set_on_post_event(global_keymap.open_help_dialog, |s| {
-        s.add_layer(view::help_view::DefaultHelpView::construct_on_event_help_view())
-    });
-
-    s.set_on_post_event(global_keymap.quit, |s| s.quit());
-}
 
 fn run() {
-    let mut s = cursive::default();
-
-    let theme = config::get_config_theme();
-    s.update_theme(|t| {
-        t.palette.set_color("view", theme.palette.background.into());
-        t.palette
-            .set_color("primary", theme.palette.foreground.into());
-        t.palette
-            .set_color("title_primary", theme.palette.foreground.into());
-        t.palette
-            .set_color("highlight", theme.palette.selection_background.into());
-        t.palette
-            .set_color("highlight_text", theme.palette.selection_foreground.into());
-    });
-
     // setup HN Client
     let client = client::init_client();
-    set_up_global_callbacks(&mut s, client);
 
-    // render `front_page` story view as the application's default view
-    view::story_view::add_story_view_layer(
-        &mut s,
-        client,
-        "front_page",
-        false,
-        0,
-        client::StoryNumericFilters::default(),
-        false,
-    );
+    // setup the application's UI
+    let s = view::init_ui(client);
 
-    // use `cursive_buffered_backend` to fix the flickering issue
-    // when using `cursive` with `crossterm_backend` (https://github.com/gyscos/Cursive/issues/142)
+    // use `cursive_buffered_backend` crate to fix the flickering issue
+    // when using `cursive` with `crossterm_backend` (See https://github.com/gyscos/Cursive/issues/142)
     let crossterm_backend = backends::crossterm::Backend::init().unwrap();
     let buffered_backend = Box::new(cursive_buffered_backend::BufferedBackend::new(
         crossterm_backend,

--- a/hackernews_tui/src/view/article_view.rs
+++ b/hackernews_tui/src/view/article_view.rs
@@ -98,7 +98,7 @@ impl ScrollViewContainer for ArticleView {
     }
 }
 
-pub fn get_article_main_view(article: client::Article) -> OnEventView<ArticleView> {
+fn construct_article_main_view(article: client::Article) -> OnEventView<ArticleView> {
     let is_suffix_key = |c: &Event| -> bool {
         let article_view_keymap = config::get_article_view_keymap();
         article_view_keymap.open_link_in_browser.has_event(c)
@@ -158,9 +158,11 @@ pub fn get_article_main_view(article: client::Article) -> OnEventView<ArticleVie
         .on_scroll_events()
 }
 
-pub fn get_article_view(article: client::Article) -> impl View {
+/// Construct an article view of an article
+pub fn construct_article_view(article: client::Article) -> impl View {
     let desc = format!("Article View - {}", article.title);
-    let main_view = get_article_main_view(article).full_height();
+    let main_view = construct_article_main_view(article).full_height();
+
     let mut view = LinearLayout::vertical()
         .child(utils::construct_view_title_bar(&desc))
         .child(main_view)
@@ -171,7 +173,8 @@ pub fn get_article_view(article: client::Article) -> impl View {
     view
 }
 
-pub fn add_article_view_layer(s: &mut Cursive, url: &str) {
-    let async_view = async_view::get_article_view_async(s, url);
+/// Retrieve an article from a given `url` and construct an article view of that article
+pub fn construct_and_add_new_article_view(s: &mut Cursive, url: &str) {
+    let async_view = async_view::construct_article_view_async(s, url);
     s.screen_mut().add_transparent_layer(Layer::new(async_view))
 }

--- a/hackernews_tui/src/view/async_view.rs
+++ b/hackernews_tui/src/view/async_view.rs
@@ -40,7 +40,7 @@ pub fn get_story_view_async(
             ResultView::new(
                 result.with_context(|| {
                     format!(
-                        "failed to get stories (tag={}, by_date={}, page={}, numeric_filters={:#?}):",
+                        "failed to get stories (tag={}, by_date={}, page={}, numeric_filters={{{}}})",
                         tag, by_date, page, numeric_filters,
                     )
                 }),

--- a/hackernews_tui/src/view/async_view.rs
+++ b/hackernews_tui/src/view/async_view.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use cursive_aligned_view::Alignable;
 use cursive_async_view::AsyncView;
 
-pub fn get_comment_view_async(
+pub fn construct_comment_view_async(
     siv: &mut Cursive,
     client: &'static client::HNClient,
     story: &client::Story,
@@ -16,7 +16,7 @@ pub fn get_comment_view_async(
         move |result: Result<_>| {
             ResultView::new(
                 result.with_context(|| format!("failed to load comments from story (id={})", id)),
-                |receiver| comment_view::get_comment_view(&story, receiver),
+                |receiver| comment_view::construct_comment_view(&story, receiver),
             )
         }
     })
@@ -25,7 +25,7 @@ pub fn get_comment_view_async(
     .full_screen()
 }
 
-pub fn get_story_view_async(
+pub fn construct_story_view_async(
     siv: &mut Cursive,
     client: &'static client::HNClient,
     tag: &'static str,
@@ -45,7 +45,7 @@ pub fn get_story_view_async(
                     )
                 }),
                 |stories| {
-                    story_view::get_story_view(stories, client, tag, by_date, page, numeric_filters)
+                    story_view::construct_story_view(stories, client, tag, by_date, page, numeric_filters)
                 },
             )
         },
@@ -55,7 +55,7 @@ pub fn get_story_view_async(
     .full_screen()
 }
 
-pub fn get_article_view_async(siv: &mut Cursive, article_url: &str) -> impl View {
+pub fn construct_article_view_async(siv: &mut Cursive, article_url: &str) -> impl View {
     let err_context = format!(
         "Failed to execute the command:\n\
          `{} {}`.\n\n\
@@ -73,7 +73,7 @@ pub fn get_article_view_async(siv: &mut Cursive, article_url: &str) -> impl View
         move |result| {
             let err_context = err_context.clone();
             ResultView::new(result.with_context(|| err_context), |article| {
-                article_view::get_article_view(article)
+                article_view::construct_article_view(article)
             })
         },
     )

--- a/hackernews_tui/src/view/mod.rs
+++ b/hackernews_tui/src/view/mod.rs
@@ -24,7 +24,7 @@ fn set_up_switch_story_view_shortcut(
     numeric_filters: Option<client::StoryNumericFilters>,
 ) {
     s.set_on_post_event(keys, move |s| {
-        story_view::add_story_view_layer(
+        story_view::construct_and_add_new_story_view(
             s,
             client,
             tag,
@@ -70,7 +70,7 @@ fn set_up_global_callbacks(s: &mut Cursive, client: &'static client::HNClient) {
         .iter()
         .for_each(|data| {
             s.set_on_post_event(data.key.clone(), move |s| {
-                story_view::add_story_view_layer(
+                story_view::construct_and_add_new_story_view(
                     s,
                     client,
                     &data.tag,
@@ -93,7 +93,7 @@ fn set_up_global_callbacks(s: &mut Cursive, client: &'static client::HNClient) {
     });
 
     s.set_on_post_event(global_keymap.goto_search_view, move |s| {
-        search_view::add_search_view_layer(s, client);
+        search_view::construct_and_add_new_search_view(s, client);
     });
 
     s.set_on_post_event(global_keymap.open_help_dialog, |s| {
@@ -124,7 +124,7 @@ pub fn init_ui(client: &'static client::HNClient) -> cursive::CursiveRunnable {
     set_up_global_callbacks(&mut s, client);
 
     // render `front_page` story view as the application's startup view
-    story_view::add_story_view_layer(
+    story_view::construct_and_add_new_story_view(
         &mut s,
         client,
         "front_page",

--- a/hackernews_tui/src/view/mod.rs
+++ b/hackernews_tui/src/view/mod.rs
@@ -11,3 +11,112 @@ pub mod comment_view;
 pub mod help_view;
 pub mod search_view;
 pub mod story_view;
+
+use crate::view::help_view::HasHelpView;
+
+use super::prelude::*;
+
+macro_rules! set_up_switch_view_shortcut {
+    ($key:expr,$tag:expr,$s:expr,$client:expr) => {
+        $s.set_on_post_event($key, move |s| {
+            story_view::add_story_view_layer(
+                s,
+                $client,
+                $tag,
+                true,
+                0,
+                client::StoryNumericFilters::default(),
+                false,
+            );
+        });
+    };
+}
+
+fn set_up_global_callbacks(s: &mut Cursive, client: &'static client::HNClient) {
+    s.clear_global_callbacks(Event::CtrlChar('c'));
+
+    let global_keymap = config::get_global_keymap().clone();
+
+    // .............................................................
+    // global shortcuts for switching between different Story Views
+    // .............................................................
+
+    set_up_switch_view_shortcut!(global_keymap.goto_front_page_view, "front_page", s, client);
+    set_up_switch_view_shortcut!(global_keymap.goto_all_stories_view, "story", s, client);
+    set_up_switch_view_shortcut!(global_keymap.goto_ask_hn_view, "ask_hn", s, client);
+    set_up_switch_view_shortcut!(global_keymap.goto_show_hn_view, "show_hn", s, client);
+    set_up_switch_view_shortcut!(global_keymap.goto_jobs_view, "job", s, client);
+
+    // custom navigation shortcuts
+    config::get_config()
+        .keymap
+        .custom_keymaps
+        .iter()
+        .for_each(|data| {
+            s.set_on_post_event(data.key.clone(), move |s| {
+                story_view::add_story_view_layer(
+                    s,
+                    client,
+                    &data.tag,
+                    data.by_date,
+                    0,
+                    data.numeric_filters,
+                    false,
+                );
+            });
+        });
+
+    // ............................................
+    // end of navigation shortcuts for Story Views
+    // ............................................
+
+    s.set_on_post_event(global_keymap.goto_previous_view, |s| {
+        if s.screen_mut().len() > 1 {
+            s.pop_layer();
+        }
+    });
+
+    s.set_on_post_event(global_keymap.goto_search_view, move |s| {
+        search_view::add_search_view_layer(s, client);
+    });
+
+    s.set_on_post_event(global_keymap.open_help_dialog, |s| {
+        s.add_layer(help_view::DefaultHelpView::construct_on_event_help_view())
+    });
+
+    s.set_on_post_event(global_keymap.quit, |s| s.quit());
+}
+
+/// Initialize the application's UI
+pub fn init_ui(client: &'static client::HNClient) -> cursive::CursiveRunnable {
+    let mut s = cursive::default();
+
+    // initialize `cursive` color palette which is determined by the application's theme
+    let theme = config::get_config_theme();
+    s.update_theme(|t| {
+        t.palette.set_color("view", theme.palette.background.into());
+        t.palette
+            .set_color("primary", theme.palette.foreground.into());
+        t.palette
+            .set_color("title_primary", theme.palette.foreground.into());
+        t.palette
+            .set_color("highlight", theme.palette.selection_background.into());
+        t.palette
+            .set_color("highlight_text", theme.palette.selection_foreground.into());
+    });
+
+    set_up_global_callbacks(&mut s, client);
+
+    // render `front_page` story view as the application's startup view
+    story_view::add_story_view_layer(
+        &mut s,
+        client,
+        "front_page",
+        false,
+        0,
+        client::StoryNumericFilters::default(),
+        false,
+    );
+
+    s
+}

--- a/hackernews_tui/src/view/mod.rs
+++ b/hackernews_tui/src/view/mod.rs
@@ -16,20 +16,24 @@ use crate::view::help_view::HasHelpView;
 
 use super::prelude::*;
 
-macro_rules! set_up_switch_view_shortcut {
-    ($key:expr,$tag:expr,$s:expr,$client:expr) => {
-        $s.set_on_post_event($key, move |s| {
-            story_view::add_story_view_layer(
-                s,
-                $client,
-                $tag,
-                true,
-                0,
-                client::StoryNumericFilters::default(),
-                false,
-            );
-        });
-    };
+fn set_up_switch_story_view_shortcut(
+    keys: config::Keys,
+    tag: &'static str,
+    s: &mut Cursive,
+    client: &'static client::HNClient,
+    numeric_filters: Option<client::StoryNumericFilters>,
+) {
+    s.set_on_post_event(keys, move |s| {
+        story_view::add_story_view_layer(
+            s,
+            client,
+            tag,
+            true,
+            0,
+            numeric_filters.unwrap_or_default(),
+            false,
+        );
+    });
 }
 
 fn set_up_global_callbacks(s: &mut Cursive, client: &'static client::HNClient) {
@@ -41,11 +45,23 @@ fn set_up_global_callbacks(s: &mut Cursive, client: &'static client::HNClient) {
     // global shortcuts for switching between different Story Views
     // .............................................................
 
-    set_up_switch_view_shortcut!(global_keymap.goto_front_page_view, "front_page", s, client);
-    set_up_switch_view_shortcut!(global_keymap.goto_all_stories_view, "story", s, client);
-    set_up_switch_view_shortcut!(global_keymap.goto_ask_hn_view, "ask_hn", s, client);
-    set_up_switch_view_shortcut!(global_keymap.goto_show_hn_view, "show_hn", s, client);
-    set_up_switch_view_shortcut!(global_keymap.goto_jobs_view, "job", s, client);
+    set_up_switch_story_view_shortcut(
+        global_keymap.goto_front_page_view,
+        "front_page",
+        s,
+        client,
+        None,
+    );
+    set_up_switch_story_view_shortcut(
+        global_keymap.goto_all_stories_view,
+        "story",
+        s,
+        client,
+        None,
+    );
+    set_up_switch_story_view_shortcut(global_keymap.goto_ask_hn_view, "ask_hn", s, client, None);
+    set_up_switch_story_view_shortcut(global_keymap.goto_show_hn_view, "show_hn", s, client, None);
+    set_up_switch_story_view_shortcut(global_keymap.goto_jobs_view, "job", s, client, None);
 
     // custom navigation shortcuts
     config::get_config()

--- a/hackernews_tui/src/view/utils.rs
+++ b/hackernews_tui/src/view/utils.rs
@@ -78,7 +78,7 @@ pub fn open_ith_link_in_article_view(links: &[String], i: usize) -> Option<Event
     if i > 0 && i <= links.len() {
         Some(EventResult::with_cb({
             let url = links[i - 1].clone();
-            move |s| article_view::add_article_view_layer(s, &url)
+            move |s| article_view::construct_and_add_new_article_view(s, &url)
         }))
     } else {
         Some(EventResult::Consumed(None))


### PR DESCRIPTION
## Brief description of changes

- moved UI initialization codes from `main.rs` to `view::mod.rs`
- updated application's logging level
- renamed functions, added more comments/code documentations
- added some code cleanups