### PR TITLE
Voting support follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
     - [Comment View](#comment-view-shortcuts)
     - [Search View](#search-view-shortcuts)
 - [Configuration](#configuration)
+- [Authentication](#authentication)
 - [Logging](#logging)
 - [Roadmap](#roadmap)
 
@@ -267,6 +268,17 @@ hackernews_tui -c ~/.config/hn-tui.toml
 ```
 
 For further information about the application's configurations, please refer to the [example config file](https://github.com/aome510/hackernews-TUI/blob/main/examples/hn-tui.toml) and the [config documentation](https://github.com/aome510/hackernews-TUI/blob/main/config.md).
+
+## Authentication
+
+Users can authenticate their account by specifying `username` and `password` inside the `hn-auth.toml` file:
+
+```toml
+username=""
+password=""
+```
+
+By default, the authentication file should be inside the same folder as the the general configuration file (`hn-tui.toml`), which can be configured by specifying the `-a` or `--auth` option.
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ For more information about configuring the application's key mappings or definin
 | `next_top_level_comment`       | Focus the next top level comment                                  | `n`              |
 | `prev_top_level_comment`       | Focus the previous top level comment                              | `p`              |
 | `parent_comment`               | Focus the parent comment (if exists)                              | `u`              |
-| `toggle_collapse_comment`      | Toggle collapsing the focused comment                             | `tab`            |
+| `toggle_collapse_comment`      | Toggle collapsing the focused item                                | `tab`            |
+| `vote`                         | Toggle voting the focused item (**requires authentication**)      | `v`              |
 | `open_article_in_browser`      | Open in browser the discussed article                             | `a`              |
 | `open_article_in_article_view` | Open in article view the discussed article                        | `A`              |
 | `open_story_in_browser`        | Open in browser the discussed story                               | `s`              |

--- a/README.md
+++ b/README.md
@@ -219,23 +219,23 @@ For more information about configuring the application's key mappings or definin
 
 #### Comment View shortcuts
 
-| Command                        | Description                                                       | Default Shortcut |
-| ------------------------------ | ----------------------------------------------------------------- | ---------------- |
-| `next_comment`                 | Focus the next comment                                            | `j`              |
-| `prev_comment`                 | Focus the previous comment                                        | `k`              |
-| `next_leq_level_comment`       | Focus the next comment with smaller or equal level                | `l`              |
-| `prev_leq_level_comment`       | Focus the previous comment with smaller or equal level            | `h`              |
-| `next_top_level_comment`       | Focus the next top level comment                                  | `n`              |
-| `prev_top_level_comment`       | Focus the previous top level comment                              | `p`              |
-| `parent_comment`               | Focus the parent comment (if exists)                              | `u`              |
-| `toggle_collapse_comment`      | Toggle collapsing the focused item                                | `tab`            |
-| `vote`                         | Toggle voting the focused item (**requires authentication**)      | `v`              |
-| `open_article_in_browser`      | Open in browser the discussed article                             | `a`              |
-| `open_article_in_article_view` | Open in article view the discussed article                        | `A`              |
-| `open_story_in_browser`        | Open in browser the discussed story                               | `s`              |
-| `open_comment_in_browser`      | Open in browser the focused comment                               | `c`              |
-| `open_link_in_browser`         | Open in browser the {link_id}-th link in the focused comment      | `{link_id} o`    |
-| `open_link_in_article_view`    | Open in article view the {link_id}-th link in the focused comment | `{link_id} O`    |
+| Command                        | Description                                                                     | Default Shortcut |
+| ------------------------------ | ------------------------------------------------------------------------------- | ---------------- |
+| `next_comment`                 | Focus the next comment                                                          | `j`              |
+| `prev_comment`                 | Focus the previous comment                                                      | `k`              |
+| `next_leq_level_comment`       | Focus the next comment with smaller or equal level                              | `l`              |
+| `prev_leq_level_comment`       | Focus the previous comment with smaller or equal level                          | `h`              |
+| `next_top_level_comment`       | Focus the next top level comment                                                | `n`              |
+| `prev_top_level_comment`       | Focus the previous top level comment                                            | `p`              |
+| `parent_comment`               | Focus the parent comment (if exists)                                            | `u`              |
+| `toggle_collapse_comment`      | Toggle collapsing the focused item                                              | `tab`            |
+| `vote`                         | Toggle voting the focused item (**requires [authentication](#authentication)**) | `v`              |
+| `open_article_in_browser`      | Open in browser the discussed article                                           | `a`              |
+| `open_article_in_article_view` | Open in article view the discussed article                                      | `A`              |
+| `open_story_in_browser`        | Open in browser the discussed story                                             | `s`              |
+| `open_comment_in_browser`      | Open in browser the focused comment                                             | `c`              |
+| `open_link_in_browser`         | Open in browser the {link_id}-th link in the focused comment                    | `{link_id} o`    |
+| `open_link_in_article_view`    | Open in article view the {link_id}-th link in the focused comment               | `{link_id} O`    |
 
 #### Search View shortcuts
 

--- a/hackernews_tui/src/client/mod.rs
+++ b/hackernews_tui/src/client/mod.rs
@@ -65,7 +65,10 @@ impl HNClient {
     }
 
     pub fn get_story_hidden_data(&self, story_id: u32) -> Result<StoryHiddenData> {
-        let content = self.get_story_page_content(story_id)?;
+        let content = log!(
+            self.get_story_page_content(story_id)?,
+            format!("get story (id={story_id}) page content")
+        );
         let vote_state = self.parse_story_vote_data(&content)?;
         let comment_receiver = self.lazy_load_story_comments(story_id)?;
 
@@ -359,12 +362,31 @@ impl HNClient {
     }
 
     pub fn get_story_page_content(&self, story_id: u32) -> Result<String> {
-        // TODO: handle cases when the story has multiple pages
-        let content = self
+        let morelink_rg = regex::Regex::new("<a.*?href='(?P<link>.*?)'.*class='morelink'.*?>")?;
+
+        let mut content = self
             .client
             .get(&format!("{HN_HOST_URL}/item?id={story_id}"))
             .call()?
             .into_string()?;
+
+        // The story returned by HN can have multiple pages,
+        // we need to make additional requests for each page and
+        // concatenate all the responses to from the story's content.
+        let mut curr_page_content = content.clone();
+
+        while let Some(cap) = morelink_rg.captures(&curr_page_content) {
+            let next_page_link = cap.name("link").unwrap().as_str().replace("&amp;", "&");
+
+            let next_page_content = self
+                .client
+                .get(&format!("{HN_HOST_URL}/{next_page_link}"))
+                .call()?
+                .into_string()?;
+
+            content.push_str(&next_page_content);
+            curr_page_content = next_page_content;
+        }
 
         Ok(content)
     }

--- a/hackernews_tui/src/client/mod.rs
+++ b/hackernews_tui/src/client/mod.rs
@@ -380,7 +380,7 @@ impl HNClient {
 
         // The story returned by HN can have multiple pages,
         // we need to make additional requests for each page and
-        // concatenate all the responses to from the story's content.
+        // concatenate all the responses to get the story's whole content.
         let mut curr_page_content = content.clone();
 
         while let Some(cap) = morelink_rg.captures(&curr_page_content) {

--- a/hackernews_tui/src/model.rs
+++ b/hackernews_tui/src/model.rs
@@ -234,6 +234,8 @@ impl Story {
 }
 
 impl HnItem {
+    /// gets the dispay text of the item, which depends on the item's states
+    /// (e.g `vote_status`, `display_state`, etc)
     pub fn text(&self, vote_status: Option<bool>) -> StyledString {
         let theme = config::get_config_theme();
 

--- a/hackernews_tui/src/model.rs
+++ b/hackernews_tui/src/model.rs
@@ -56,9 +56,9 @@ pub struct HnItem {
     pub id: u32,
     pub level: usize,
     pub display_state: DisplayState,
-    pub text: StyledString,
-    pub minimized_text: StyledString,
     pub links: Vec<String>,
+    text: StyledString,
+    minimized_text: StyledString,
 }
 
 #[derive(Debug, Clone)]
@@ -81,7 +81,7 @@ impl From<Story> for HnItem {
     fn from(story: Story) -> Self {
         let component_style = &config::get_config_theme().component_style;
 
-        let metadata = utils::combine_styled_strings(vec![
+        let metadata = utils::combine_styled_strings([
             story.styled_title(),
             StyledString::plain("\n"),
             StyledString::styled(
@@ -106,7 +106,7 @@ impl From<Story> for HnItem {
         } else {
             story_text = format!("\n{story_text}");
 
-            utils::combine_styled_strings(vec![metadata.clone(), StyledString::plain("... (more)")])
+            utils::combine_styled_strings([metadata.clone(), StyledString::plain("... (more)")])
         };
 
         let mut text = metadata;
@@ -128,7 +128,7 @@ impl From<Comment> for HnItem {
     fn from(comment: Comment) -> Self {
         let component_style = &config::get_config_theme().component_style;
 
-        let metadata = utils::combine_styled_strings(vec![
+        let metadata = utils::combine_styled_strings([
             StyledString::styled(comment.author, component_style.username),
             StyledString::styled(
                 format!(" {} ago ", utils::get_elapsed_time_as_text(comment.time)),
@@ -136,9 +136,8 @@ impl From<Comment> for HnItem {
             ),
         ]);
 
-        let mut text =
-            utils::combine_styled_strings(vec![metadata.clone(), StyledString::plain("\n")]);
-        let minimized_text = utils::combine_styled_strings(vec![
+        let mut text = utils::combine_styled_strings([metadata.clone(), StyledString::plain("\n")]);
+        let minimized_text = utils::combine_styled_strings([
             metadata,
             StyledString::styled(
                 format!("({} more)", comment.n_children + 1),
@@ -231,5 +230,24 @@ impl Story {
     /// Get the story's plain title
     pub fn plain_title(&self) -> String {
         self.title.replace("<em>", "").replace("</em>", "") // story's title from the search view can have `<em>` inside it
+    }
+}
+
+impl HnItem {
+    pub fn text(&self, vote_status: Option<bool>) -> StyledString {
+        let theme = config::get_config_theme();
+
+        let text = match self.display_state {
+            DisplayState::Hidden => unreachable!("Hidden item's text shouldn't be accessed"),
+            DisplayState::Minimized => self.minimized_text.clone(),
+            DisplayState::Normal => self.text.clone(),
+        };
+        let vote_text = match vote_status {
+            Some(true) => StyledString::styled("▲ ", theme.palette.green),
+            Some(false) => StyledString::plain("▲ "),
+            None => StyledString::plain(""),
+        };
+
+        utils::combine_styled_strings([vote_text, text])
     }
 }

--- a/hackernews_tui/src/utils.rs
+++ b/hackernews_tui/src/utils.rs
@@ -49,11 +49,17 @@ pub fn shorten_url(url: &str) -> String {
     }
 }
 /// Combine multiple styled strings into a single styled string
-pub fn combine_styled_strings(strings: Vec<StyledString>) -> StyledString {
-    strings.into_iter().fold(StyledString::new(), |mut acc, s| {
-        acc.append(s);
-        acc
-    })
+pub fn combine_styled_strings<S>(strings: S) -> StyledString
+where
+    S: Into<Vec<StyledString>>,
+{
+    strings
+        .into()
+        .into_iter()
+        .fold(StyledString::new(), |mut acc, s| {
+            acc.append(s);
+            acc
+        })
 }
 
 /// decode a HTML encoded string

--- a/hackernews_tui/src/view/async_view.rs
+++ b/hackernews_tui/src/view/async_view.rs
@@ -89,7 +89,7 @@ fn animation(width: usize, _height: usize, frame_idx: usize) -> cursive_async_vi
         let factor = (frame_idx as f64) / (n_frames as f64);
         let x = (factor * width as f64) as usize;
 
-        let content = crate::utils::combine_styled_strings(vec![
+        let content = crate::utils::combine_styled_strings([
             StyledString::styled(repeat_str("- ", x / 2), style),
             StyledString::styled('ᗧ', style),
             StyledString::styled(repeat_str(" o", width.saturating_sub(x + 1) / 2), style),
@@ -104,7 +104,7 @@ fn animation(width: usize, _height: usize, frame_idx: usize) -> cursive_async_vi
         let factor = (frame_idx as f64) / (n_frames as f64);
         let x = (factor * width as f64) as usize;
 
-        let content = crate::utils::combine_styled_strings(vec![
+        let content = crate::utils::combine_styled_strings([
             StyledString::styled(repeat_str(symbol, x), style.back),
             StyledString::styled(repeat_str(symbol, width - x), style.front),
         ]);

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -214,8 +214,7 @@ impl CommentView {
         self.update_item_text_content(id);
     }
 
-    /// Update the `id`-th item's text content based on its state-based text,
-    /// which changes depending on the item's state.
+    /// Update the `id`-th item's text content based on its state-based text
     pub fn update_item_text_content(&mut self, id: usize) {
         let new_content = self.items[id].text(self.get_vote_status(self.items[id].id));
         self.get_item_view_mut(id)
@@ -306,7 +305,7 @@ fn construct_comment_main_view(
                     }
                 });
 
-                // assume the vote request always succeed because we don't want users
+                // assume the vote request always succeeds because we don't want users
                 // to feel a delay as a result of the request's latency when voting.
                 *upvoted = !(*upvoted);
                 s.update_item_text_content(id);

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -35,12 +35,7 @@ impl CommentView {
                     0,
                     1,
                     text_view::TextView::new(
-                        item.text(
-                            data.vote_state
-                                .get(&item.id.to_string())
-                                .map(|v| v.upvoted)
-                                .clone(),
-                        ),
+                        item.text(data.vote_state.get(&item.id.to_string()).map(|v| v.upvoted)),
                     ),
                 )))
                 .scrollable(),
@@ -142,7 +137,6 @@ impl CommentView {
             .vote_state
             .get(&item_id.to_string())
             .map(|v| v.upvoted)
-            .clone()
     }
 
     fn get_item_view(&self, id: usize) -> &SingleItemView {
@@ -202,8 +196,7 @@ impl CommentView {
     /// Toggle the collapsing state of currently focused item and its children
     pub fn toggle_collapse_focused_item(&mut self) {
         let id = self.get_focus_index();
-        let item = self.items[id].clone();
-        match item.display_state {
+        match self.items[id].display_state {
             DisplayState::Hidden => {
                 panic!(
                     "invalid collapse state `Collapsed` when calling `toggle_collapse_focused_item`"
@@ -217,7 +210,13 @@ impl CommentView {
                 self.items[id].display_state = DisplayState::Minimized;
             }
         };
-        let new_content = item.text(self.get_vote_status(item.id));
+        self.update_item_text_content(id);
+    }
+
+    /// Update the `id`-th item's text content based on its state-based text,
+    /// which changes depending on the item's state.
+    pub fn update_item_text_content(&mut self, id: usize) {
+        let new_content = self.items[id].text(self.get_vote_status(self.items[id].id));
         self.get_item_view_mut(id)
             .get_inner_mut()
             .get_inner_mut()
@@ -301,6 +300,7 @@ fn construct_comment_main_view(
                     Ok(_) => {
                         // update the focused item's vote status if the request succeeds
                         *upvoted = !(*upvoted);
+                        s.update_item_text_content(id);
                     }
                 }
             }

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -153,13 +153,13 @@ impl CommentView {
             .unwrap()
     }
 
-    /// Toggle the collapsing state of items whose level is greater than the `min_level`.
-    fn toggle_item_collapse_state(&mut self, start_id: usize, min_level: usize) {
+    /// Toggle the collapsing state of items whose levels are greater than the `min_level`.
+    fn toggle_items_collapse_state(&mut self, start_id: usize, min_level: usize) {
         // This function will be called recursively until it's unable to find any items.
         //
-        // **Note**: `PartiallyCollapsed` item's state is unchanged, we only toggle its visibility.
+        // Note: collapsed item's state is unchanged, we only toggle its visibility.
         // Also, the state and visibility of such item's children are unaffected as they should already
-        // be in a collapsed state.
+        // be in a hidden state (as result of that item's collapsed state).
         if start_id == self.len() || self.items[start_id].level <= min_level {
             return;
         }
@@ -167,12 +167,12 @@ impl CommentView {
             DisplayState::Hidden => {
                 self.items[start_id].display_state = DisplayState::Normal;
                 self.get_item_view_mut(start_id).unhide();
-                self.toggle_item_collapse_state(start_id + 1, min_level)
+                self.toggle_items_collapse_state(start_id + 1, min_level)
             }
             DisplayState::Normal => {
                 self.items[start_id].display_state = DisplayState::Hidden;
                 self.get_item_view_mut(start_id).hide();
-                self.toggle_item_collapse_state(start_id + 1, min_level)
+                self.toggle_items_collapse_state(start_id + 1, min_level)
             }
             DisplayState::Minimized => {
                 let component = self.get_item_view_mut(start_id);
@@ -188,7 +188,7 @@ impl CommentView {
                     self.items[start_id].level,
                     NavigationDirection::Next,
                 );
-                self.toggle_item_collapse_state(next_id, min_level)
+                self.toggle_items_collapse_state(next_id, min_level)
             }
         };
     }
@@ -203,10 +203,11 @@ impl CommentView {
                 );
             }
             DisplayState::Minimized => {
-                self.toggle_item_collapse_state(id + 1, self.items[id].level);
+                self.toggle_items_collapse_state(id + 1, self.items[id].level);
                 self.items[id].display_state = DisplayState::Normal;
             }
             DisplayState::Normal => {
+                self.toggle_items_collapse_state(id + 1, self.items[id].level);
                 self.items[id].display_state = DisplayState::Minimized;
             }
         };

--- a/hackernews_tui/src/view/help_view.rs
+++ b/hackernews_tui/src/view/help_view.rs
@@ -426,10 +426,16 @@ impl HasHelpView for comment_view::CommentView {
             CommandGroup::new(
                 "Others",
                 [
-                    vec![Command::new(
-                        comment_view_keymap.toggle_collapse_comment.to_string(),
-                        "Toggle collapsing the focused comment",
-                    )],
+                    vec![
+                        Command::new(
+                            comment_view_keymap.toggle_collapse_comment.to_string(),
+                            "Toggle collapsing the focused item",
+                        ),
+                        Command::new(
+                            comment_view_keymap.vote.to_string(),
+                            "Toggle voting the focused item",
+                        ),
+                    ],
                     default_other_commands(),
                 ]
                 .concat(),


### PR DESCRIPTION
## Changes

- added voting visualization
- handled voting command asynchronously to avoid blocking
- fixed bug (from #84) that made collapsed item's children not hidden
- handled multi-paged stories when getting story's 
- added authentication/voting documentations