### PR TITLE
Support opening specific comment view on startup

### DIFF
--- a/hackernews_tui/src/client/mod.rs
+++ b/hackernews_tui/src/client/mod.rs
@@ -112,13 +112,13 @@ impl HNClient {
         // Parallelize two tasks using [`rayon::join`](https://docs.rs/rayon/latest/rayon/fn.join.html)
         let (vote_state, comment_receiver) = rayon::join(
             || {
-                // get the page content
+                // get the page's vote state
                 log!(
                     {
                         let content = self.get_page_content(item_id)?;
                         self.parse_vote_data(&content)
                     },
-                    format!("get page content (id={item_id}) ")
+                    format!("get page's vote state of item (id={item_id}) ")
                 )
             },
             // lazily load the page's top comments

--- a/hackernews_tui/src/client/model.rs
+++ b/hackernews_tui/src/client/model.rs
@@ -62,6 +62,19 @@ pub struct StoryResponse {
 #[derive(Debug, Deserialize)]
 /// ItemResponse represents the item data received from the official HackerNews APIs
 pub struct ItemResponse {
+    pub id: u32,
+    pub by: Option<String>,
+    pub text: Option<String>,
+    pub title: Option<String>,
+    pub url: Option<String>,
+
+    #[serde(rename(deserialize = "type"))]
+    pub typ: String,
+
+    pub descendants: Option<usize>,
+    pub score: Option<u32>,
+    pub time: u64,
+
     #[serde(default)]
     pub kids: Vec<u32>,
 }

--- a/hackernews_tui/src/client/model.rs
+++ b/hackernews_tui/src/client/model.rs
@@ -60,8 +60,8 @@ pub struct StoryResponse {
 }
 
 #[derive(Debug, Deserialize)]
-/// HNStoryResponse represents the story data received from the official HackerNews APIs
-pub struct HNStoryResponse {
+/// ItemResponse represents the item data received from the official HackerNews APIs
+pub struct ItemResponse {
     #[serde(default)]
     pub kids: Vec<u32>,
 }

--- a/hackernews_tui/src/main.rs
+++ b/hackernews_tui/src/main.rs
@@ -14,7 +14,7 @@ const DEFAULT_LOG_FILE: &str = "hn-tui.log";
 use clap::*;
 use prelude::*;
 
-fn run(auth: Option<config::Auth>, start_id: Option<usize>) {
+fn run(auth: Option<config::Auth>, start_id: Option<u32>) {
     // setup HN Client
     let client = client::init_client();
 
@@ -26,7 +26,7 @@ fn run(auth: Option<config::Auth>, start_id: Option<usize>) {
     }
 
     // setup the application's UI
-    let s = view::init_ui(client);
+    let s = view::init_ui(client, start_id);
 
     // use `cursive_buffered_backend` crate to fix the flickering issue
     // when using `cursive` with `crossterm_backend` (See https://github.com/gyscos/Cursive/issues/142)

--- a/hackernews_tui/src/main.rs
+++ b/hackernews_tui/src/main.rs
@@ -14,7 +14,7 @@ const DEFAULT_LOG_FILE: &str = "hn-tui.log";
 use clap::*;
 use prelude::*;
 
-fn run(auth: Option<config::Auth>) {
+fn run(auth: Option<config::Auth>, start_id: Option<usize>) {
     // setup HN Client
     let client = client::init_client();
 
@@ -95,6 +95,13 @@ fn parse_args(config_dir: std::path::PathBuf, cache_dir: std::path::PathBuf) -> 
                 .help("Path to a folder to store application's logs")
                 .next_line_help(true),
         )
+        .arg(
+            Arg::new("start_id")
+                .short('i')
+                .value_parser(clap::value_parser!(u32))
+                .help("The Hacker News item's id to start the application with")
+                .next_line_help(true),
+        )
         .get_matches()
 }
 
@@ -140,5 +147,6 @@ fn main() {
         args.get_one::<String>("auth")
             .expect("`auth` argument should have a default value"),
     );
-    run(auth);
+    let start_id = args.get_one::<u32>("start_id").cloned();
+    run(auth, start_id);
 }

--- a/hackernews_tui/src/model.rs
+++ b/hackernews_tui/src/model.rs
@@ -37,7 +37,12 @@ pub struct Comment {
 }
 
 pub struct PageData {
-    /// a channel to lazily load items in the page
+    pub title: String,
+    pub url: String,
+
+    pub root_item: HnItem,
+
+    /// a channel to lazily load items/comments in the page
     pub comment_receiver: CommentReceiver,
     /// the voting state of items in the page
     pub vote_state: HashMap<String, VoteData>,

--- a/hackernews_tui/src/model.rs
+++ b/hackernews_tui/src/model.rs
@@ -36,8 +36,10 @@ pub struct Comment {
     pub content: String,
 }
 
-pub struct StoryHiddenData {
+pub struct PageData {
+    /// a channel to lazily load items in the page
     pub comment_receiver: CommentReceiver,
+    /// the voting state of items in the page
     pub vote_state: HashMap<String, VoteData>,
 }
 

--- a/hackernews_tui/src/model.rs
+++ b/hackernews_tui/src/model.rs
@@ -36,10 +36,14 @@ pub struct Comment {
     pub content: String,
 }
 
+/// A Hacker News page data.
+///
+/// The page data is mainly used to construct a comment view.
 pub struct PageData {
     pub title: String,
     pub url: String,
 
+    /// the root item in the page
     pub root_item: HnItem,
 
     /// a channel to lazily load items/comments in the page

--- a/hackernews_tui/src/view/async_view.rs
+++ b/hackernews_tui/src/view/async_view.rs
@@ -7,16 +7,13 @@ use cursive_async_view::AsyncView;
 pub fn construct_comment_view_async(
     siv: &mut Cursive,
     client: &'static client::HNClient,
-    story: &Story,
+    item_id: u32,
 ) -> impl View {
-    let id = story.id;
-
-    AsyncView::new_with_bg_creator(siv, move || Ok(client.get_story_hidden_data(id)), {
-        let story = story.clone();
+    AsyncView::new_with_bg_creator(siv, move || Ok(client.get_page_data(item_id)), {
         move |result: Result<_>| {
             ResultView::new(
-                result.with_context(|| format!("failed to load comments from story (id={id})")),
-                |receiver| comment_view::construct_comment_view(client, &story, receiver),
+                result.with_context(|| format!("failed to load comments from item (id={item_id})")),
+                |data| comment_view::construct_comment_view(client, data),
             )
         }
     })

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -415,11 +415,6 @@ fn construct_comment_main_view(client: &'static client::HNClient, data: PageData
         .full_height()
 }
 
-/// Construct a comment view of a given story.
-///
-/// # Arguments:
-/// * `story`: a Hacker News story
-/// * `receiver`: a "subscriber" channel that gets comments asynchronously from another thread
 pub fn construct_comment_view(client: &'static client::HNClient, data: PageData) -> impl View {
     let title = format!("Comment View - {}", data.title,);
     let main_view = construct_comment_main_view(client, data);
@@ -434,7 +429,7 @@ pub fn construct_comment_view(client: &'static client::HNClient, data: PageData)
     view
 }
 
-/// Retrieve comments of a story and construct a comment view of that story
+/// Retrieve comments in a Hacker News item and construct a comment view of that item
 pub fn construct_and_add_new_comment_view(
     s: &mut Cursive,
     client: &'static client::HNClient,

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -8,7 +8,7 @@ type SingleItemView = HideableView<PaddedView<text_view::TextView>>;
 pub struct CommentView {
     view: ScrollView<LinearLayout>,
     items: Vec<HnItem>,
-    data: StoryHiddenData,
+    data: PageData,
 
     raw_command: String,
 }
@@ -23,7 +23,7 @@ impl ViewWrapper for CommentView {
 }
 
 impl CommentView {
-    pub fn new(story: &Story, data: StoryHiddenData) -> Self {
+    pub fn new(story: &Story, data: PageData) -> Self {
         // story as the first item in the comment view
         let item: HnItem = story.clone().into();
 
@@ -258,7 +258,7 @@ impl ScrollViewContainer for CommentView {
 fn construct_comment_main_view(
     client: &'static client::HNClient,
     story: &Story,
-    data: StoryHiddenData,
+    data: PageData,
 ) -> impl View {
     let is_suffix_key = |c: &Event| -> bool {
         let comment_view_keymap = config::get_comment_view_keymap();
@@ -420,11 +420,7 @@ fn construct_comment_main_view(
 /// # Arguments:
 /// * `story`: a Hacker News story
 /// * `receiver`: a "subscriber" channel that gets comments asynchronously from another thread
-pub fn construct_comment_view(
-    client: &'static client::HNClient,
-    story: &Story,
-    data: StoryHiddenData,
-) -> impl View {
+pub fn construct_comment_view(client: &'static client::HNClient, data: PageData) -> impl View {
     let main_view = construct_comment_main_view(client, story, data);
 
     let mut view = LinearLayout::vertical()
@@ -444,10 +440,10 @@ pub fn construct_comment_view(
 pub fn construct_and_add_new_comment_view(
     s: &mut Cursive,
     client: &'static client::HNClient,
-    story: &Story,
+    item_id: u32,
     pop_layer: bool,
 ) {
-    let async_view = async_view::construct_comment_view_async(s, client, story);
+    let async_view = async_view::construct_comment_view_async(s, client, item_id);
     if pop_layer {
         s.pop_layer();
     }

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -265,7 +265,8 @@ fn construct_comment_main_view(client: &'static client::HNClient, data: PageData
 
     let comment_view_keymap = config::get_comment_view_keymap().clone();
 
-    let page_url = data.url.clone();
+    let article_url = data.url.clone();
+    let page_url = format!("{}/item?id={}", client::HN_HOST_URL, data.root_item.id);
 
     OnEventView::new(CommentView::new(data))
         .on_pre_event_inner(EventTrigger::from_fn(|_| true), move |s, e| {
@@ -388,13 +389,13 @@ fn construct_comment_main_view(client: &'static client::HNClient, data: PageData
             Some(EventResult::Consumed(None))
         })
         .on_pre_event(comment_view_keymap.open_article_in_browser, {
-            let url = page_url.clone();
+            let url = article_url.clone();
             move |_| {
                 utils::open_url_in_browser(&url);
             }
         })
         .on_pre_event(comment_view_keymap.open_article_in_article_view, {
-            let url = page_url.clone();
+            let url = article_url;
             move |s| {
                 if !url.is_empty() {
                     article_view::construct_and_add_new_article_view(s, &url)
@@ -402,7 +403,7 @@ fn construct_comment_main_view(client: &'static client::HNClient, data: PageData
             }
         })
         .on_pre_event(comment_view_keymap.open_story_in_browser, {
-            let url = page_url.clone();
+            let url = page_url;
             move |_| {
                 utils::open_url_in_browser(&url);
             }

--- a/hackernews_tui/src/view/fn_view_wrapper.rs
+++ b/hackernews_tui/src/view/fn_view_wrapper.rs
@@ -31,7 +31,7 @@ macro_rules! impl_view_fns_for_fn_view_wrapper {
             self.get_view_mut().take_focus(source)
         }
 
-        fn call_on_any<'a>(&mut self, selector: &Selector<'_>, callback: AnyCb<'a>) {
+        fn call_on_any(&mut self, selector: &Selector<'_>, callback: AnyCb<'_>) {
             self.get_view_mut().call_on_any(selector, callback)
         }
 

--- a/hackernews_tui/src/view/mod.rs
+++ b/hackernews_tui/src/view/mod.rs
@@ -114,7 +114,7 @@ fn set_up_global_callbacks(s: &mut Cursive, client: &'static client::HNClient) {
 /// Initialize the application's UI
 pub fn init_ui(
     client: &'static client::HNClient,
-    start_id: Option<usize>,
+    start_id: Option<u32>,
 ) -> cursive::CursiveRunnable {
     let mut s = cursive::default();
 
@@ -135,7 +135,9 @@ pub fn init_ui(
     set_up_global_callbacks(&mut s, client);
 
     match start_id {
-        Some(id) => todo!(),
+        Some(id) => {
+            comment_view::construct_and_add_new_comment_view(&mut s, client, id, false);
+        }
         None => {
             // render `front_page` story view as the application's startup view if no start id is specified
             story_view::construct_and_add_new_story_view(

--- a/hackernews_tui/src/view/mod.rs
+++ b/hackernews_tui/src/view/mod.rs
@@ -112,7 +112,10 @@ fn set_up_global_callbacks(s: &mut Cursive, client: &'static client::HNClient) {
 }
 
 /// Initialize the application's UI
-pub fn init_ui(client: &'static client::HNClient) -> cursive::CursiveRunnable {
+pub fn init_ui(
+    client: &'static client::HNClient,
+    start_id: Option<usize>,
+) -> cursive::CursiveRunnable {
     let mut s = cursive::default();
 
     // initialize `cursive` color palette which is determined by the application's theme
@@ -131,16 +134,21 @@ pub fn init_ui(client: &'static client::HNClient) -> cursive::CursiveRunnable {
 
     set_up_global_callbacks(&mut s, client);
 
-    // render `front_page` story view as the application's startup view
-    story_view::construct_and_add_new_story_view(
-        &mut s,
-        client,
-        "front_page",
-        client::StorySortMode::None,
-        0,
-        client::StoryNumericFilters::default(),
-        false,
-    );
+    match start_id {
+        Some(id) => todo!(),
+        None => {
+            // render `front_page` story view as the application's startup view if no start id is specified
+            story_view::construct_and_add_new_story_view(
+                &mut s,
+                client,
+                "front_page",
+                client::StorySortMode::None,
+                0,
+                client::StoryNumericFilters::default(),
+                false,
+            );
+        }
+    }
 
     s
 }

--- a/hackernews_tui/src/view/story_view.rs
+++ b/hackernews_tui/src/view/story_view.rs
@@ -168,9 +168,9 @@ pub fn construct_story_main_view(
             let id = s.get_focus_index();
             // the story struct hasn't had any comments inside yet,
             // so it can be cloned without greatly affecting performance
-            let story = s.stories[id].clone();
+            let item_id = s.stories[id].id;
             Some(EventResult::with_cb({
-                move |s| comment_view::construct_and_add_new_comment_view(s, client, &story, false)
+                move |s| comment_view::construct_and_add_new_comment_view(s, client, item_id, false)
             }))
         })
         // open external link shortcuts


### PR DESCRIPTION
Resolves #86 

## Changes
- added `--start_id` cli option to open the application in a specific comment view
- updated comment view codes to
   + not require a story to construct a comment view
   + allow constructing a comment view of either a comment or a story