### PR TITLE
Implement Rust native article view as fallback on failed `article_parse_command`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.9",
  "once_cell",
  "version_check",
 ]
@@ -109,6 +109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +190,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
@@ -330,6 +342,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754b69d351cdc2d8ee09ae203db831e005560fc6030da058f86ad60c92a9cb0a"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa 0.4.8",
+ "matches",
+ "phf 0.8.0",
+ "proc-macro2",
+ "quote",
+ "smallvec",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "cursive"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +481,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +519,21 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dtoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbaceec3c6e4211c79e7b1800fb9680527106beb2f9c51904a3210c03a448c74"
+dependencies = [
+ "dtoa",
+]
 
 [[package]]
 name = "either"
@@ -572,6 +639,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,7 +666,7 @@ checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -598,11 +685,12 @@ dependencies = [
  "cursive_core",
  "dirs-next",
  "html-escape",
- "html5ever",
+ "html5ever 0.26.0",
  "log",
- "markup5ever",
+ "markup5ever 0.11.0",
  "once_cell",
  "rayon",
+ "readable-readability",
  "regex",
  "serde",
  "serde_json",
@@ -653,13 +741,27 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c13fb08e5d4dfc151ee5e88bae63f7773d61852f3bdc73c9f4b9e1bde03148"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.10.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "html5ever"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.11.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -722,6 +824,12 @@ dependencies = [
 
 [[package]]
 name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
@@ -733,6 +841,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kuchiki"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea8e9c6e031377cff82ee3001dc8026cdf431ed4e2e6b51f98ab8c73484a358"
+dependencies = [
+ "cssparser",
+ "html5ever 0.25.2",
+ "matches",
+ "selectors",
 ]
 
 [[package]]
@@ -777,13 +897,27 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markup5ever"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd"
+dependencies = [
+ "log",
+ "phf 0.8.0",
+ "phf_codegen 0.8.0",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
 dependencies = [
  "log",
- "phf",
- "phf_codegen",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
  "string_cache",
  "string_cache_codegen",
  "tendril",
@@ -797,6 +931,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -830,7 +970,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -839,6 +979,12 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nu-ansi-term"
@@ -997,11 +1143,32 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "phf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.8.0",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+dependencies = [
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
 ]
 
 [[package]]
@@ -1010,8 +1177,18 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+dependencies = [
+ "phf_shared 0.8.0",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -1020,8 +1197,31 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
- "phf_shared",
- "rand",
+ "phf_shared 0.10.0",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
+dependencies = [
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -1052,6 +1252,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,13 +1277,37 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+ "rand_pcg",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1087,7 +1317,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1096,7 +1335,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.9",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1122,6 +1379,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "readable-readability"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17015928a25bff296b0471dfa7a784e406664e1d091781db66e885b18708a8d"
+dependencies = [
+ "html5ever 0.25.2",
+ "kuchiki",
+ "lazy_static",
+ "log",
+ "regex",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,7 +1407,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.9",
  "redox_syscall",
  "thiserror",
 ]
@@ -1186,6 +1457,15 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -1243,6 +1523,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "selectors"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df320f1889ac4ba6bc0cdc9c9af7af4bd64bb927bccdf32d81140dc1f9be12fe"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "fxhash",
+ "log",
+ "matches",
+ "phf 0.8.0",
+ "phf_codegen 0.8.0",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
+ "thin-slice",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+
+[[package]]
 name = "send_wrapper"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,7 +1580,7 @@ version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
- "itoa",
+ "itoa 1.0.6",
  "ryu",
  "serde",
 ]
@@ -1286,6 +1592,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
+dependencies = [
+ "nodrop",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1360,7 +1676,7 @@ dependencies = [
  "new_debug_unreachable",
  "once_cell",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
 ]
@@ -1371,8 +1687,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
  "proc-macro2",
  "quote",
 ]
@@ -1436,6 +1752,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thin-slice"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
+
+[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,7 +1793,7 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
- "itoa",
+ "itoa 1.0.6",
  "libc",
  "num_threads",
  "serde",
@@ -1704,6 +2026,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/docs/config.md
+++ b/docs/config.md
@@ -44,6 +44,8 @@ An example config file (with some default config values) can be found in [exampl
 2. a command explicitly specified by `article_parse_command` option in your config file
 3. an integrated parser powered by [`readable-readability`](https://crates.io/crates/readable-readability) crate 
 
+Please note that if you want to use the integrated parser, you **must** uninstall (1) `article_md` from your `$PATH`, and (2) remove `article_parse_command` setting from your config file. There is no way to explicitly specify to use the integrated parser.
+
 You can specify another tool with the `article_parse_command` config option. An `article_parse_command` must be a command that returns result with the following schema:
 
 ```typescript
@@ -64,7 +66,6 @@ One alternative is [`mercury-parser`](https://github.com/postlight/mercury-parse
 article_parse_command = { command = 'mercury-parser', options = [] }
 ```
 
-Please note that if you want to use the integrated parser, you **must** uninstall (1) `article_md` from your `$PATH`, and (2) remove `article_parse_command` setting from your config file. There is no way to explicitly specify to use the integrated parser.
 
 ## Theme
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -38,9 +38,13 @@ An example config file (with some default config values) can be found in [exampl
 
 ### Article Parse Command
 
-To enable viewing an article's content in reader mode with `ArticleView`, user will need to install **additional** tools and specify the `article_parse_command` config option.
+`hackernews-TUI` will display an article's content in reader mode with `ArticleView`. To parse the article's content into a readable text, it will use a command in the following precedence: 
 
-An `article_parse_command` must be a command that returns result with the following schema:
+1. [`article_md`](https://github.com/aome510/article-md-cli) in your `$PATH`
+2. a command explicitly specified by `article_parse_command` option in your config file
+3. an integrated parser powered by [`readable-readability`](https://crates.io/crates/readable-readability) crate 
+
+You can specify another tool with the `article_parse_command` config option. An `article_parse_command` must be a command that returns result with the following schema:
 
 ```typescript
 type result_schema = {
@@ -52,15 +56,15 @@ type result_schema = {
 };
 ```
 
-The returned `content` **must** be a **HTML string** respresenting the article's content in reader mode.
-
-By default, `hackernews-TUI` uses [`article_md`](https://github.com/aome510/article-md-cli) as the default command for parsing articles.
+The returned `content` **must** be an **HTML string** representing the article's content in reader mode.
 
 One alternative is [`mercury-parser`](https://github.com/postlight/mercury-parser#installation):
 
 ```toml
 article_parse_command = { command = 'mercury-parser', options = [] }
 ```
+
+Please note that if you want to use the integrated parser, you **must** uninstall (1) `article_md` from your `$PATH`, and (2) remove `article_parse_command` setting from your config file. There is no way to explicitly specify to use the integrated parser.
 
 ## Theme
 

--- a/hackernews_tui/Cargo.toml
+++ b/hackernews_tui/Cargo.toml
@@ -24,6 +24,9 @@ html5ever = "0.26.0"
 markup5ever = "0.11.0"
 tendril = "0.4.3"
 
+# internal article view dep
+readable-readability = "0.4.0"
+
 # tracing/log related deps
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }

--- a/hackernews_tui/src/client/mod.rs
+++ b/hackernews_tui/src/client/mod.rs
@@ -55,8 +55,8 @@ impl HNClient {
     /// Get data of a HN item based on its id then parse the data
     /// to a corresponding struct representing that item
     pub fn get_item_from_id<T>(&self, id: u32) -> Result<T>
-        where
-            T: serde::de::DeserializeOwned,
+    where
+        T: serde::de::DeserializeOwned,
     {
         let request_url = format!("{HN_ALGOLIA_PREFIX}/items/{id}");
         let item = log!(
@@ -107,7 +107,7 @@ impl HNClient {
                 title: title.clone(),
                 content: text,
             }
-                .into(),
+            .into(),
             "comment" => Comment {
                 id: item_id,
                 level: 0,
@@ -116,7 +116,7 @@ impl HNClient {
                 time: item.time,
                 content: text,
             }
-                .into(),
+            .into(),
             typ => {
                 anyhow::bail!("unknown item type: {typ}");
             }
@@ -405,21 +405,23 @@ impl HNClient {
             }
             Err(_) => {
                 // fallback to the `readable-readability` crate if the command fails
-                let html = self.client
+                let html = self
+                    .client
                     .get(url)
                     .call()
                     .with_context(|| "failed to get url")?
                     .into_string()
                     .with_context(|| "failed to turn the response into string")?;
                 let (nodes, metadata) = readable_readability::Readability::new()
-                    .base_url(url::Url::parse(url)
-                        .with_context(|| "failed to parse url")?)
+                    .base_url(url::Url::parse(url).with_context(|| "failed to parse url")?)
                     .parse(&html);
 
                 let mut text = vec![];
-                nodes.serialize(&mut text)
+                nodes
+                    .serialize(&mut text)
                     .with_context(|| "failed to serialize nodes")?;
-                let title = metadata.page_title
+                let title = metadata
+                    .page_title
                     .or(metadata.article_title)
                     .unwrap_or("(no title)".to_string());
                 let content = std::str::from_utf8(&text)

--- a/hackernews_tui/src/client/mod.rs
+++ b/hackernews_tui/src/client/mod.rs
@@ -373,7 +373,7 @@ impl HNClient {
         Ok(response.into())
     }
 
-    pub fn get_article(url: &str) -> Result<Article> {
+    pub fn get_article(&self, url: &str) -> Result<Article> {
         let article_parse_command = &config::get_config().article_parse_command;
         let output = std::process::Command::new(&article_parse_command.command)
             .args(&article_parse_command.options)
@@ -405,9 +405,7 @@ impl HNClient {
             }
             Err(_) => {
                 // fallback to the `readable-readability` crate if the command fails
-                let html = ureq::AgentBuilder::new()
-                    .timeout(std::time::Duration::from_secs(config::get_config().client_timeout))
-                    .build()
+                let html = self.client
                     .get(url)
                     .call()
                     .with_context(|| "failed to get url")?

--- a/hackernews_tui/src/view/article_view.rs
+++ b/hackernews_tui/src/view/article_view.rs
@@ -98,7 +98,7 @@ impl ScrollViewContainer for ArticleView {
     }
 }
 
-fn construct_article_main_view(article: Article) -> OnEventView<ArticleView> {
+fn construct_article_main_view(client: &'static client::HNClient, article: Article) -> OnEventView<ArticleView> {
     let is_suffix_key = |c: &Event| -> bool {
         let article_view_keymap = config::get_article_view_keymap();
         article_view_keymap.open_link_in_browser.has_event(c)
@@ -121,11 +121,11 @@ fn construct_article_main_view(article: Article) -> OnEventView<ArticleView> {
             };
             None
         })
-        .on_pre_event_inner(article_view_keymap.open_link_dialog, |s, _| {
+        .on_pre_event_inner(article_view_keymap.open_link_dialog, move |s, _| {
             Some(EventResult::with_cb({
                 let links = s.links.clone();
                 move |s| {
-                    s.add_layer(link_dialog::get_link_dialog(&links));
+                    s.add_layer(link_dialog::get_link_dialog(client, &links));
                 }
             }))
         })
@@ -140,10 +140,10 @@ fn construct_article_main_view(article: Article) -> OnEventView<ArticleView> {
         })
         .on_pre_event_inner(
             article_view_keymap.open_link_in_article_view,
-            |s, _| match s.raw_command.parse::<usize>() {
+            move |s, _| match s.raw_command.parse::<usize>() {
                 Ok(num) => {
                     s.raw_command.clear();
-                    utils::open_ith_link_in_article_view(&s.links, num)
+                    utils::open_ith_link_in_article_view(client, &s.links, num)
                 }
                 Err(_) => None,
             },
@@ -159,9 +159,9 @@ fn construct_article_main_view(article: Article) -> OnEventView<ArticleView> {
 }
 
 /// Construct an article view of an article
-pub fn construct_article_view(article: Article) -> impl View {
+pub fn construct_article_view(client: &'static client::HNClient, article: Article) -> impl View {
     let desc = format!("Article View - {}", article.title);
-    let main_view = construct_article_main_view(article).full_height();
+    let main_view = construct_article_main_view(client, article).full_height();
 
     let mut view = LinearLayout::vertical()
         .child(utils::construct_view_title_bar(&desc))
@@ -174,7 +174,7 @@ pub fn construct_article_view(article: Article) -> impl View {
 }
 
 /// Retrieve an article from a given `url` and construct an article view of that article
-pub fn construct_and_add_new_article_view(s: &mut Cursive, url: &str) {
-    let async_view = async_view::construct_article_view_async(s, url);
+pub fn construct_and_add_new_article_view(client: &'static client::HNClient, s: &mut Cursive, url: &str) {
+    let async_view = async_view::construct_article_view_async(client, s, url);
     s.screen_mut().add_transparent_layer(Layer::new(async_view))
 }

--- a/hackernews_tui/src/view/article_view.rs
+++ b/hackernews_tui/src/view/article_view.rs
@@ -98,7 +98,10 @@ impl ScrollViewContainer for ArticleView {
     }
 }
 
-fn construct_article_main_view(client: &'static client::HNClient, article: Article) -> OnEventView<ArticleView> {
+fn construct_article_main_view(
+    client: &'static client::HNClient,
+    article: Article,
+) -> OnEventView<ArticleView> {
     let is_suffix_key = |c: &Event| -> bool {
         let article_view_keymap = config::get_article_view_keymap();
         article_view_keymap.open_link_in_browser.has_event(c)
@@ -174,7 +177,11 @@ pub fn construct_article_view(client: &'static client::HNClient, article: Articl
 }
 
 /// Retrieve an article from a given `url` and construct an article view of that article
-pub fn construct_and_add_new_article_view(client: &'static client::HNClient, s: &mut Cursive, url: &str) {
+pub fn construct_and_add_new_article_view(
+    client: &'static client::HNClient,
+    s: &mut Cursive,
+    url: &str,
+) {
     let async_view = async_view::construct_article_view_async(client, s, url);
     s.screen_mut().add_transparent_layer(Layer::new(async_view))
 }

--- a/hackernews_tui/src/view/async_view.rs
+++ b/hackernews_tui/src/view/async_view.rs
@@ -3,6 +3,7 @@ use crate::prelude::*;
 use anyhow::Context;
 use cursive_aligned_view::Alignable;
 use cursive_async_view::AsyncView;
+use crate::client;
 
 pub fn construct_comment_view_async(
     siv: &mut Cursive,
@@ -51,7 +52,7 @@ pub fn construct_story_view_async(
     .full_screen()
 }
 
-pub fn construct_article_view_async(siv: &mut Cursive, article_url: &str) -> impl View {
+pub fn construct_article_view_async(client: &'static client::HNClient, siv: &mut Cursive, article_url: &str) -> impl View {
     let err_context = format!(
         "Failed to execute the command:\n\
          `{} {}`.\n\n\
@@ -64,12 +65,12 @@ pub fn construct_article_view_async(siv: &mut Cursive, article_url: &str) -> imp
         siv,
         {
             let article_url = article_url.to_owned();
-            move || Ok(client::HNClient::get_article(&article_url))
+            move || Ok(client::HNClient::get_article(client, &article_url))
         },
         move |result| {
             let err_context = err_context.clone();
             ResultView::new(result.with_context(|| err_context), |article| {
-                article_view::construct_article_view(article)
+                article_view::construct_article_view(client, article)
             })
         },
     )

--- a/hackernews_tui/src/view/async_view.rs
+++ b/hackernews_tui/src/view/async_view.rs
@@ -54,11 +54,10 @@ pub fn construct_story_view_async(
 
 pub fn construct_article_view_async(client: &'static client::HNClient, siv: &mut Cursive, article_url: &str) -> impl View {
     let err_context = format!(
-        "Failed to execute the command:\n\
-         `{} {}`.\n\n\
-         Please make sure you have configured the `article_parse_command` option as described in the below link:\n\
+        "Failed to parse an article into readable text:\n\
+         `{}`.\n\n\
+         Please review your configuration as described in the below link, and try again\n\
          \"https://github.com/aome510/hackernews-TUI/blob/main/docs/config.md#article-parse-command\"",
-        config::get_config().article_parse_command,
         article_url);
 
     AsyncView::new_with_bg_creator(

--- a/hackernews_tui/src/view/async_view.rs
+++ b/hackernews_tui/src/view/async_view.rs
@@ -1,9 +1,9 @@
 use super::{article_view, comment_view, result_view::ResultView, story_view};
+use crate::client;
 use crate::prelude::*;
 use anyhow::Context;
 use cursive_aligned_view::Alignable;
 use cursive_async_view::AsyncView;
-use crate::client;
 
 pub fn construct_comment_view_async(
     siv: &mut Cursive,
@@ -52,7 +52,11 @@ pub fn construct_story_view_async(
     .full_screen()
 }
 
-pub fn construct_article_view_async(client: &'static client::HNClient, siv: &mut Cursive, article_url: &str) -> impl View {
+pub fn construct_article_view_async(
+    client: &'static client::HNClient,
+    siv: &mut Cursive,
+    article_url: &str,
+) -> impl View {
     let err_context = format!(
         "Failed to parse an article into readable text:\n\
          `{}`.\n\n\

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -369,10 +369,10 @@ fn construct_comment_main_view(client: &'static client::HNClient, data: PageData
         })
         .on_pre_event_inner(
             comment_view_keymap.open_link_in_article_view,
-            |s, _| match s.raw_command.parse::<usize>() {
+            move |s, _| match s.raw_command.parse::<usize>() {
                 Ok(num) => {
                     s.raw_command.clear();
-                    utils::open_ith_link_in_article_view(&s.items[s.get_focus_index()].links, num)
+                    utils::open_ith_link_in_article_view(client, &s.items[s.get_focus_index()].links, num)
                 }
                 Err(_) => None,
             },
@@ -398,7 +398,7 @@ fn construct_comment_main_view(client: &'static client::HNClient, data: PageData
             let url = article_url;
             move |s| {
                 if !url.is_empty() {
-                    article_view::construct_and_add_new_article_view(s, &url)
+                    article_view::construct_and_add_new_article_view(client, s, &url)
                 }
             }
         })

--- a/hackernews_tui/src/view/comment_view.rs
+++ b/hackernews_tui/src/view/comment_view.rs
@@ -372,7 +372,11 @@ fn construct_comment_main_view(client: &'static client::HNClient, data: PageData
             move |s, _| match s.raw_command.parse::<usize>() {
                 Ok(num) => {
                     s.raw_command.clear();
-                    utils::open_ith_link_in_article_view(client, &s.items[s.get_focus_index()].links, num)
+                    utils::open_ith_link_in_article_view(
+                        client,
+                        &s.items[s.get_focus_index()].links,
+                        num,
+                    )
                 }
                 Err(_) => None,
             },

--- a/hackernews_tui/src/view/link_dialog.rs
+++ b/hackernews_tui/src/view/link_dialog.rs
@@ -47,7 +47,7 @@ impl LinkDialog {
     }
 }
 
-pub fn get_link_dialog(links: &[String]) -> impl View {
+pub fn get_link_dialog(client: &'static client::HNClient, links: &[String]) -> impl View {
     let view = LinkDialog::new(links);
     let link_dialog_keymap = config::get_link_dialog_keymap().clone();
 
@@ -87,6 +87,7 @@ pub fn get_link_dialog(links: &[String]) -> impl View {
             let links = links.to_owned();
             move |s, _| {
                 utils::open_ith_link_in_article_view(
+                    client,
                     &links,
                     s.content().get_inner().get_focus_index() + 1,
                 )

--- a/hackernews_tui/src/view/story_view.rs
+++ b/hackernews_tui/src/view/story_view.rs
@@ -186,7 +186,7 @@ pub fn construct_story_main_view(
                 let url = s.stories[id].url.clone();
                 if !url.is_empty() {
                     Some(EventResult::with_cb({
-                        move |s| article_view::construct_and_add_new_article_view(s, &url)
+                        move |s| article_view::construct_and_add_new_article_view(client, s, &url)
                     }))
                 } else {
                     Some(EventResult::Consumed(None))

--- a/hackernews_tui/src/view/utils.rs
+++ b/hackernews_tui/src/view/utils.rs
@@ -74,11 +74,11 @@ pub fn open_url_in_browser(url: &str) {
 
 /// open in article view the `i`-th link.
 /// Note that the link index starts with `1`.
-pub fn open_ith_link_in_article_view(links: &[String], i: usize) -> Option<EventResult> {
+pub fn open_ith_link_in_article_view(client: &'static client::HNClient, links: &[String], i: usize) -> Option<EventResult> {
     if i > 0 && i <= links.len() {
         Some(EventResult::with_cb({
             let url = links[i - 1].clone();
-            move |s| article_view::construct_and_add_new_article_view(s, &url)
+            move |s| article_view::construct_and_add_new_article_view(client, s, &url)
         }))
     } else {
         Some(EventResult::Consumed(None))

--- a/hackernews_tui/src/view/utils.rs
+++ b/hackernews_tui/src/view/utils.rs
@@ -74,7 +74,11 @@ pub fn open_url_in_browser(url: &str) {
 
 /// open in article view the `i`-th link.
 /// Note that the link index starts with `1`.
-pub fn open_ith_link_in_article_view(client: &'static client::HNClient, links: &[String], i: usize) -> Option<EventResult> {
+pub fn open_ith_link_in_article_view(
+    client: &'static client::HNClient,
+    links: &[String],
+    i: usize,
+) -> Option<EventResult> {
     if i > 0 && i <= links.len() {
         Some(EventResult::with_cb({
             let url = links[i - 1].clone();


### PR DESCRIPTION
First of all, thank you for bringing this great TUI for us!

### Summary

Implement Rust native article view as fallback on failed `article_parse_command`.

### Context

Current implementation will display a link to the [`config.md`](https://github.com/aome510/hackernews-TUI/blob/main/docs/config.md#article-parse-command) file if the `article_parse_command` fails. Almost all of new users will see this error. Instead, we can use the `readable-readability` to provide similar capability as a fallback method. This might be more user friendly and nice default behavior. 

### Dependency Added

- [`readable-readability`](https://crates.io/crates/readable-readability)

### Screenshots

https://news.ycombinator.com/item?id=37214693

|`article_md`|New implementation|
|-|-|
|![article_md 1](https://github.com/aome510/hackernews-TUI/assets/679719/a85e6f5b-d003-44c4-9270-72555535631d)|![integrated 1](https://github.com/aome510/hackernews-TUI/assets/679719/5edcc5d8-d339-431b-a331-90d51833df46)|

Please note that it's not perfect for some pages as below, but I think it'd be acceptable.

https://news.ycombinator.com/item?id=25607320

|`article_md`|New implementation|
|-|-|
|![aritcle_md 2](https://github.com/aome510/hackernews-TUI/assets/679719/87702be2-aa88-4169-8199-f83e677c761a)|![integrated 2](https://github.com/aome510/hackernews-TUI/assets/679719/1302615c-058b-4277-a97a-4d06ff439550)|

### Final Words

Quick and not-so-scientific benchmarking shows that the native implementation is faster than the `article_md`, separate Node.js CLI, on my setup. This is just a proposal. I'm not sure if it's a good idea to add a new dependency to the project. Feel free to close this PR if you don't like it. If you like it, I'd add commits to update relevant documentation. Thank you!