### PR TITLE
Add Scoop installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ ln -sf $PWD/target/release/hackernews_tui /usr/local/bin
 
 to link the executable binary to `/usr/local/bin` folder.
 
+### Windows
+
+#### Via Scoop
+
+Run `scoop install hackernews-tui` to install the application.
+
 ### macOS
 
 #### Via MacPorts


### PR DESCRIPTION
`hackernews-tui` has been added to Scoop's Main (default) bucket - https://github.com/ScoopInstaller/Main/pull/5157 - making it easy to install on Windows.