### PR TITLE
Update Hacker News HTML text parsing logic

### DIFF
--- a/hackernews_tui/src/client/mod.rs
+++ b/hackernews_tui/src/client/mod.rs
@@ -77,9 +77,7 @@ impl HNClient {
             format!("get item (id={item_id}) using {request_url}")
         );
 
-        // The item's text returned from HN official APIs may have `<p>` tags representing
-        // paragraph breaks. Convert `<p>` tags to newlines to make the text easier to read.
-        let text = decode_html(&item.text.unwrap_or_default()).replace("<p>", "\n\n");
+        let text = decode_html(&item.text.unwrap_or_default());
 
         // Construct the shortened text to represent the page's title if not exist
         let chars = text.replace('\n', " ").chars().collect::<Vec<_>>();

--- a/hackernews_tui/src/parser/html.rs
+++ b/hackernews_tui/src/parser/html.rs
@@ -4,21 +4,21 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 /// A regex to parse a HN text (in HTML).
-/// It consists of multiple regex(s) representing different elements.
+/// It consists of multiple regexes representing different components.
 static HN_TEXT_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(&format!(
         "(({})|({})|({})|({})|({})|({}))",
-        // a regex that matches a HTML paragraph
+        // a regex matching a HTML paragraph
         r"<p>(?s)(?P<paragraph>(|[^>].*?))</p>",
-        // a regex that matches a paragraph quote (in markdown format)
+        // a regex matching a paragraph quote (in markdown format)
         r"<p>(?s)(?P<quote>>[> ]*)(?P<text>.*?)</p>",
-        // a regex that matches an HTML italic string
+        // a regex matching an HTML italic string
         r"<i>(?s)(?P<italic>.*?)</i>",
-        // a regex that matches a HTML code block (multiline)
+        // a regex matching a HTML code block (multiline)
         r"<pre><code>(?s)(?P<multiline_code>.*?)[\n]*</code></pre>",
-        // a regex that matches a single line code block (markdown format)
+        // a regex matching a single line code block (markdown format)
         r"`(?P<code>[^`]+?)`",
-        // a regex that matches a HTML link
+        // a regex matching a HTML link
         r#"<a\s+?href="(?P<link>.*?)"(?s).+?</a>"#,
     ))
     .unwrap()
@@ -53,24 +53,37 @@ impl HTMLTextParsedResult {
 }
 
 /// parse a Hacker News HTML text
-pub fn parse_hn_html_text(text: String, style: Style, base_link_id: usize) -> HTMLParsedResult {
+pub fn parse_hn_html_text(text: String, style: Style, base_link_id: usize) -> HTMLTextParsedResult {
     debug!("parse hn html text: {}", text);
 
-    let mut result = HTMLParsedResult::default();
-    // an index such that `text[curr_pos..]` represents the part of the
+    // pre-processed the HTML text
+    let text = {
+        // The item's text returned from HN APIs may have `<p>` tags representing
+        // paragraph breaks. Convert `<p>` tags to <p></p> tag pairs to make the text
+        // easier to parse.
+        if text.is_empty() {
+            text
+        } else {
+            format!("<p>{}</p>", text.replace("<p>", "</p>\n<p>"))
+        }
+    };
+
+    parse(text, style, base_link_id)
+}
+
+/// a helper function of [parse_hn_html_text] for recursively parsing HTML elements inside the text
+fn parse(text: String, style: Style, base_link_id: usize) -> HTMLTextParsedResult {
+    let mut result = HTMLTextParsedResult::default();
+    // an index such that `text[curr_pos..]` represents the slice of the
     // text that hasn't been parsed.
     let mut curr_pos = 0;
-
-    // This variable indicates whether we have parsed the first paragraph of the current text.
-    // It is used to add a break between 2 consecutive paragraphs.
-    let mut seen_first_paragraph = false;
 
     for caps in HN_TEXT_RE.captures_iter(&text) {
         // the part that doesn't match any patterns is rendered in the default style
         let whole_match = caps.get(0).unwrap();
         if curr_pos < whole_match.start() {
             result
-                .s
+                .content
                 .append_styled(&text[curr_pos..whole_match.start()], style);
         }
         curr_pos = whole_match.end();
@@ -78,71 +91,67 @@ pub fn parse_hn_html_text(text: String, style: Style, base_link_id: usize) -> HT
         let component_style = &config::get_config_theme().component_style;
 
         if let (Some(m_quote), Some(m_text)) = (caps.name("quote"), caps.name("text")) {
-            if seen_first_paragraph {
-                result.s.append_plain("\n");
-            } else {
-                seen_first_paragraph = true;
-            }
-
-            // render quote character `>` as indentation character
-            result.s.append_styled(
+            // quoted paragraph
+            // render quote character `>` using the `|` indentation character
+            result.content.append_styled(
                 "▎"
                     .to_string()
                     .repeat(m_quote.as_str().matches('>').count()),
                 style,
             );
-            result.merge(parse_hn_html_text(
+            result.merge(parse(
                 m_text.as_str().to_string(),
                 component_style.quote.into(),
                 base_link_id + result.links.len(),
             ));
 
-            result.s.append_plain("\n");
+            result.content.append_plain("\n");
         } else if let Some(m) = caps.name("paragraph") {
-            if seen_first_paragraph {
-                result.s.append_plain("\n");
-            } else {
-                seen_first_paragraph = true;
-            }
-
-            result.merge(parse_hn_html_text(
+            // normal paragraph
+            result.merge(parse(
                 m.as_str().to_string(),
                 style,
                 base_link_id + result.links.len(),
             ));
 
-            result.s.append_plain("\n");
+            result.content.append_plain("\n");
         } else if let Some(m) = caps.name("link") {
+            // HTML link
             result.links.push(m.as_str().to_string());
 
-            result.s.append_styled(
+            result.content.append_styled(
                 utils::shorten_url(m.as_str()),
                 style.combine(component_style.link),
             );
-            result.s.append_styled(" ", style);
-            result.s.append_styled(
+            result.content.append_styled(" ", style);
+            result.content.append_styled(
                 format!("[{}]", result.links.len() + base_link_id),
                 style.combine(component_style.link_id),
             );
         } else if let Some(m) = caps.name("multiline_code") {
-            result.s.append_styled(
+            // HTML code block
+            result.content.append_styled(
                 m.as_str(),
                 style.combine(component_style.multiline_code_block),
             );
-            result.s.append_plain("\n");
+            result.content.append_plain("\n");
         } else if let Some(m) = caps.name("code") {
+            // markdown single line code block
             result
-                .s
+                .content
                 .append_styled(m.as_str(), style.combine(component_style.single_code_block));
         } else if let Some(m) = caps.name("italic") {
+            // HTML italic
             result
-                .s
+                .content
                 .append_styled(m.as_str(), style.combine(component_style.italic));
         }
     }
 
     if curr_pos < text.len() {
-        result.s.append_styled(&text[curr_pos..text.len()], style);
+        result
+            .content
+            .append_styled(&text[curr_pos..text.len()], style);
     }
 
     result

--- a/hackernews_tui/src/parser/html.rs
+++ b/hackernews_tui/src/parser/html.rs
@@ -24,16 +24,16 @@ static HN_TEXT_RE: Lazy<Regex> = Lazy::new(|| {
     .unwrap()
 });
 
-/// A HTML parsed result.
+/// Parsed result of a HTML text
 #[derive(Debug, Default)]
-pub struct HTMLParsedResult {
-    /// a styled string representing the decorated HTML content
-    pub s: StyledString,
+pub struct HTMLTextParsedResult {
+    /// parsed HTML content
+    pub content: StyledString,
     /// a list of links inside the HTML document
     pub links: Vec<String>,
 }
 
-/// A HTML table parsed result.
+/// Parsed result of a HTML table
 #[derive(Debug, Default)]
 pub struct HTMLTableParsedResult {
     /// a list of links inside the HTML document
@@ -44,9 +44,10 @@ pub struct HTMLTableParsedResult {
     pub rows: Vec<Vec<StyledString>>,
 }
 
-impl HTMLParsedResult {
-    pub fn merge(&mut self, mut other: HTMLParsedResult) {
-        self.s.append(other.s);
+impl HTMLTextParsedResult {
+    /// merge two HTML parsed results
+    pub fn merge(&mut self, mut other: HTMLTextParsedResult) {
+        self.content.append(other.content);
         self.links.append(&mut other.links);
     }
 }

--- a/hackernews_tui/src/view/article_view.rs
+++ b/hackernews_tui/src/view/article_view.rs
@@ -24,7 +24,7 @@ impl ViewWrapper for ArticleView {
 
             match self.article.parse(self.width.saturating_sub(5)) {
                 Ok(result) => {
-                    self.set_article_content(result.s);
+                    self.set_article_content(result.content);
                     self.links = result.links;
                 }
                 Err(err) => {


### PR DESCRIPTION
## Changes

- update parsing logic to reflect new HN Algolia API change regarding the use of `<p>` for paragraph breaks
- cleanup parsing codes