### PR TITLE
Update CD workflows to use use `cross`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,20 +21,13 @@ jobs:
             target: aarch64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            container: rust
             dependencies: "libssl-dev libasound2-dev libdbus-1-dev"
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            container: rustembedded/cross:aarch64-unknown-linux-gnu
-            cross_arch: "arm64"
-            pkg_config_path: "/usr/lib/aarch64-linux-gnu/pkgconfig/"
-            dependencies: "libssl-dev:arm64 libasound2-dev:arm64 libdbus-1-dev:arm64"
+            cross_arch: true
           - os: ubuntu-latest
             target: armv7-unknown-linux-gnueabihf
-            cross_arch: "armhf"
-            pkg_config_path: "/usr/lib/arm-linux-gnueabihf/pkgconfig/"
-            container: rustembedded/cross:armv7-unknown-linux-gnueabihf
-            dependencies: "libssl-dev:armhf libasound2-dev:armhf libdbus-1-dev:armhf"
+            cross_arch: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
 
@@ -42,28 +35,19 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
 
-      - name: Set up cross compilation
-        if: matrix.cross_arch
-        run: |
-          dpkg --add-architecture ${{ matrix.cross_arch }}
-          echo "PKG_CONFIG_PATH=${{ matrix.pkg_config_path }}" >> $GITHUB_ENV
-          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
-
       - name: Install Linux dependencies
         if: matrix.dependencies
-        run: apt update && apt install -y ${{ matrix.dependencies }}
+        run: sudo apt-get update && sudo apt-get install -y ${{ matrix.dependencies }}
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
-          profile: minimal
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
 
       - name: Build
         uses: actions-rs/cargo@v1
         with:
+          use-cross: ${{ matrix.cross_arch }}
           command: build
           args: --locked --release --target ${{ matrix.target }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,7 +21,7 @@ jobs:
             target: aarch64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            dependencies: "libssl-dev libasound2-dev libdbus-1-dev"
+            dependencies: "libssl-dev"
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             cross_arch: true

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,11 @@
+[build.env]
+passthrough = [
+  "CROSS_DEBUG",
+  "RUST_BACKTRACE",
+]
+
+[target.aarch64-unknown-linux-gnu]
+dockerfile = "./ci/Dockerfile-cross"
+
+[target.armv7-unknown-linux-gnueabihf]
+dockerfile = "./ci/Dockerfile-cross"

--- a/ci/Dockerfile-cross
+++ b/ci/Dockerfile-cross
@@ -1,0 +1,8 @@
+ARG CROSS_BASE_IMAGE
+FROM $CROSS_BASE_IMAGE
+
+ARG CROSS_DEB_ARCH
+RUN dpkg --add-architecture $CROSS_DEB_ARCH && \
+    apt-get update && \
+    apt-get install -y libssl-dev:$CROSS_DEB_ARCH libasound2-dev:$CROSS_DEB_ARCH libdbus-1-dev:$CROSS_DEB_ARCH
+

--- a/ci/Dockerfile-cross
+++ b/ci/Dockerfile-cross
@@ -4,5 +4,4 @@ FROM $CROSS_BASE_IMAGE
 ARG CROSS_DEB_ARCH
 RUN dpkg --add-architecture $CROSS_DEB_ARCH && \
     apt-get update && \
-    apt-get install -y libssl-dev:$CROSS_DEB_ARCH libasound2-dev:$CROSS_DEB_ARCH libdbus-1-dev:$CROSS_DEB_ARCH
-
+    apt-get install -y libssl-dev:$CROSS_DEB_ARCH

--- a/hackernews_tui/src/parser/mod.rs
+++ b/hackernews_tui/src/parser/mod.rs
@@ -2,4 +2,4 @@ mod article;
 mod html;
 mod rcdom;
 
-pub use {article::*, html::*};
+pub use html::*;


### PR DESCRIPTION
You and I both know I copy-pasted this, no need to repeat ourselves lol. I changed the dependencies to the ones this project needs, though, of course.

* build: local cross compilation

With the intention of migrating gh action to native solution with cross

Supported targets: aarch-64-linux-gnu, armv7-unknown-linux-gnueabihf Use cross build --target (target)

Note: docker base images have been updated. See related documentation: https://github.com/cross-rs/cross/wiki/FAQ#custom-images

* build(cd): use cross for CD

Update container images along with it. Also a couple actions.

Use action-rs/cargo only for the built in support. It is the documented gh actions way in the cross README. Manually would probably increase times significantly.

See Aome510/spotify-player#343