### PR TITLE
docs: Fix wrong link to config documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ User can also specify the path to config file when running the application with 
 hackernews_tui -c ~/.config/hn-tui.toml
 ```
 
-For further information about the application's configurations, please refer to the [example config file](https://github.com/aome510/hackernews-TUI/blob/main/examples/hn-tui.toml) and the [config documentation](https://github.com/aome510/hackernews-TUI/blob/main/config.md).
+For further information about the application's configurations, please refer to the [example config file](https://github.com/aome510/hackernews-TUI/blob/main/examples/hn-tui.toml) and the [config documentation](https://github.com/aome510/hackernews-TUI/blob/main/docs/config.md).
 
 ## Authentication
 

--- a/hackernews_tui/src/client/model.rs
+++ b/hackernews_tui/src/client/model.rs
@@ -62,7 +62,6 @@ pub struct StoryResponse {
 #[derive(Debug, Deserialize)]
 /// ItemResponse represents the item data received from the official HackerNews APIs
 pub struct ItemResponse {
-    pub id: u32,
     pub by: Option<String>,
     pub text: Option<String>,
     pub title: Option<String>,

--- a/hackernews_tui/src/parser/rcdom.rs
+++ b/hackernews_tui/src/parser/rcdom.rs
@@ -74,8 +74,8 @@ pub enum NodeData {
     /// [dtd wiki]: https://en.wikipedia.org/wiki/Document_type_declaration
     Doctype {
         name: StrTendril,
-        public_id: StrTendril,
-        system_id: StrTendril,
+        _public_id: StrTendril,
+        _system_id: StrTendril,
     },
 
     /// A text node.
@@ -379,8 +379,8 @@ impl TreeSink for RcDom {
             &self.document,
             Node::new(NodeData::Doctype {
                 name,
-                public_id,
-                system_id,
+                _public_id: public_id,
+                _system_id: system_id,
             }),
         );
     }


### PR DESCRIPTION
Just a fix for an outdated link in the Read Me :smiley: 