### PR TITLE
Support proxy

### DIFF
--- a/hackernews_tui/Cargo.toml
+++ b/hackernews_tui/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 
 # others
-ureq = { version = "2.10.0", features = ["json", "cookies"] }
+ureq = { version = "2.10.0", features = ["json", "cookies", "proxy-from-env"] }
 anyhow = "1.0.86"
 rayon = "1.10.0"
 regex = "1.10.5"

--- a/hackernews_tui/Cargo.toml
+++ b/hackernews_tui/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 
 # others
-ureq = { version = "2.10.0", features = ["json", "cookies", "proxy-from-env"] }
+ureq = { version = "2.10.0", features = ["json", "cookies", "proxy-from-env", "socks-proxy"] }
 anyhow = "1.0.86"
 rayon = "1.10.0"
 regex = "1.10.5"


### PR DESCRIPTION
Fixes #43

hackernews-TUI uses [ureq 2.10.0](https://github.com/algesten/ureq/tree/2.10.0) as its HTTP client library, it supports proxies via features `proxy-from-env` to load proxy settings from environment variable, and `socks-proxy` to support socks proxies.

`ureq` has 3.x and feature `proxy-from-env` is enabled by default there, but I didn't bump it to 3.x to avoid compatibility issues, only adding these 2 features.

Locally I've tested them to work very well with http and sock5 proxies.

For users really need things to work right now before this PR is merged, you may just

```
cargo install --git https://github.com/utensil/hackernews-TUI --branch proxy hackernews_tui --locked
```

So you are good to go!